### PR TITLE
fix: EfZendDB fix false written of $object with a string instead of an array

### DIFF
--- a/library/Erfurt/Store/Adapter/EfZendDb.php
+++ b/library/Erfurt/Store/Adapter/EfZendDb.php
@@ -479,7 +479,7 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
         }
 
         if ($object !== null && strlen($object['value']) > $this->_getSchemaRefThreshold()) {
-            $object = substr($object['value'], 0, 128) . md5($object['value']);
+            $object['value'] = substr($object['value'], 0, 128) . md5($object['value']);
         }
 
         $whereString = '1';


### PR DESCRIPTION
Fix: because later there is a access to the array $object['value'] but the $object array were overwritten with a string

wrong version:
`$object = substr($object['value'], 0, 128) . md5($object['value']);`

right version:
`$object['value'] = substr($object['value'], 0, 128) . md5($object['value']);`
