### PR TITLE
Fix different array related stuff to avoid warnings

### DIFF
--- a/library/Erfurt/Cache/Frontend/QueryCache.php
+++ b/library/Erfurt/Cache/Frontend/QueryCache.php
@@ -171,8 +171,14 @@ class Erfurt_Cache_Frontend_QueryCache {
      *  @return     int      $count     number of queries which was affected of the invalidation process
     */
     public function invalidate( $modelIri, $subject, $predicate, $object ) {
+        // cast subject and predicate to string
+        $subject = (string) $subject;
+        $predicate = (string) $predicate;
+        
+        // initialize statements array
         $statements = array();
-        $statements[$subject][$predicate][] = $object ;
+        $statements[$subject] = array();
+        $statements[$subject][$predicate] = array ($object);
 
         $qids = $this->invalidateWithStatements($modelIri, $statements);
         return $qids;

--- a/library/Erfurt/Store/Adapter/Virtuoso.php
+++ b/library/Erfurt/Store/Adapter/Virtuoso.php
@@ -324,8 +324,8 @@ class Erfurt_Store_Adapter_Virtuoso implements Erfurt_Store_Adapter_Interface, E
             } else {
                 $objectSpec = $this->buildLiteralString(
                     $object['value'],
-                    array_key_exists('datatype', $object) ? $object['datatype'] : null,
-                    array_key_exists('lang', $object) ? $object['lang'] : null
+                    true == isset ($object['datatype']) ? $object['datatype'] : null,
+                    true == isset ($object['lang']) ? $object['lang'] : null
                 );
             }
         } else {

--- a/library/Erfurt/Versioning.php
+++ b/library/Erfurt/Versioning.php
@@ -349,13 +349,14 @@ class Erfurt_Versioning
         $this->_checkSetup();
 
         if (is_array($event->statement)) {
-            $payload = array (
-                $event->statement['subject'] => array (
-                    $event->statement['predicate'] => array (
-                        $event->statement['object']
-                    )
-                 )
-            );
+
+            $s = (string) $event->statement['subject'];
+            $p = (string) $event->statement['predicate'];
+            $o = $event->statement['object'];
+
+            $payload = array ();
+            $payload [$s] = array ();
+            $payload [$s][$p] = array ($o);
 
             $payloadId = $this->_execAddPayload($payload);
             $resource = $event->statement['subject'];


### PR DESCRIPTION
## Introduction

Following errors occurs during simple **addStatement** and **deleteMatchingStatement** calls. Backend is Virtuoso 6.1.4. In defiance of the following warnings, everything works as expected, but we ought fix the warnings anyway! How? Use this pull request :)
### Scenario code fragments

Here is some of my code, that you can see what i did to cause the warnings. I guess its nothing special, isn't it?

```
/**
 * Add statement
 */
// set type(uri or literal)
$type = true == Erfurt_Uri::check($o) 
    ? 'uri' : 'literal';

// add a triple to datastore
return $this->_m->addStatement(
     $s,
     $p, 
     array('value' => $o, 'type' => $type)
);

...

/**
 * Remove statement
 */
$s = $result ['s']; $p = $result ['p'];  // both are strings!

// object is always a literal!
$o = array ( 'type' => Erfurt_Store::TYPE_LITERAL, 'value' => $result ['o'] ); 

// delete matching statements on the current selected model
$this->_m->deleteMatchingStatements ( $s, $p, $o );

```
## library/Erfurt/Cache/Frontend/QueryCache.php

This code

```
$statements[$subject][$predicate][] = $object;
```

throws the following warning:

> Warning: Illegal offset type in .../ow/libraries/Erfurt/library/Erfurt/Cache/Frontend/QueryCache.php on line 175

To fix this, i added 

```
$subject = (string) $subject;
$predicate = (string) $predicate;
```

before to

```
$subject = (string) $subject;
$predicate = (string) $predicate;
$statements[$subject][$predicate][] = $object ;
```
## /library/Erfurt/Versioning.php

Same warning

> Warning: Illegal offset type in .../ow/libraries/Erfurt/library/Erfurt/Versioning.php on line 360

for this code

```
$payload = array (
    $event->statement['subject'] => array (
        $event->statement['predicate'] => array (
            $event->statement['object']
        )
     )
);
```

To fix this, use this instead:

```
$s = (string) $event->statement['subject'];
$p = (string) $event->statement['predicate'];
$o = $event->statement['object'];

$payload = array ();
$payload [$s] = array ();
$payload [$s][$p] = array ($o);
```
## /library/Erfurt/Store/Adapter/Virtuoso.php

The following code 

```
$objectSpec = $this->buildLiteralString(
    $object['value'],
    array_key_exists('datatype', $object) ? $object['datatype'] : null,
    array_key_exists('lang', $object) ? $object['lang'] : null
);
```

causes a warning sometimes about maybe unset datatype or lang key. Don't ask me why, but using isset instead of array_key_exists makes the warning go away.

```
$objectSpec = $this->buildLiteralString(
    $object['value'],
    true == isset ($object['datatype']) ? $object['datatype'] : null,
    true == isset ($object['lang']) ? $object['lang'] : null
);
```
