### PR TITLE
fix rdf import warning by turtle/n3 files

### DIFF
--- a/library/Erfurt/Syntax/RdfParser/Adapter/Turtle.php
+++ b/library/Erfurt/Syntax/RdfParser/Adapter/Turtle.php
@@ -27,6 +27,8 @@ class Erfurt_Syntax_RdfParser_Adapter_Turtle extends Erfurt_Syntax_RdfParser_Ada
     
     protected $_bnodeCounter = 0;
     
+    protected $_dataLength = 0;
+    
     protected $_usedBnodeIds = array();
     
     protected $_statements = array();


### PR DESCRIPTION
If I make an import like this

```
$this->_store->importRdf('http://www.test.de', 'dispediaWebsite_local.n3', $filetype, $locator);
```

I become this warning

```
Notice: Undefined property: Erfurt_Syntax_RdfParser_Adapter_Turtle::$_dataLength in /media/Share/Projekte/Dispedia/OW/libraries/Erfurt/library/Erfurt/Syntax/RdfParser/Adapter/Turtle.php on line 1020
```

because of the protected variable __dataLength_ has not been initialized, I fixed this with commit afc699e, maybe you want to include this changes
