### PR TITLE
Add support for store transactions

### DIFF
--- a/library/Erfurt/Store.php
+++ b/library/Erfurt/Store.php
@@ -486,6 +486,7 @@ class Erfurt_Store
             $options['use_ac'] = true;
         }
 
+        $ret = 0;
         if ($this->_checkAc($graphUri, 'edit', $options['use_ac'])) {
             try {
                 $ret = $this->_backendAdapter->deleteMatchingStatements(
@@ -495,9 +496,10 @@ class Erfurt_Store
                 $queryCache = Erfurt_App::getInstance()->getQueryCache();
                 $queryCache->invalidate($graphUri, $subject, $predicate, $object);
 
-                $event = new Erfurt_Event('onDeleteMatchingStatements');
-                $event->graphUri = $graphUri;
-                $event->resource = $subject;
+                $event                     = new Erfurt_Event('onDeleteMatchingStatements');
+                $event->graphUri           = $graphUri;
+                $event->resource           = $subject;
+                $event->affectedStatements = $ret;
 
                 // just trigger if really data operations were performed
                 if ((int) $ret > 0) {
@@ -513,8 +515,12 @@ class Erfurt_Store
                 $event->graphUri = $graphUri;
                 $event->resource = $subject;
                 Erfurt_Event_Dispatcher::getInstance()->trigger($event);
+
+                throw new Erfurt_Store_Exception($e->getMessage());
             }
         }
+
+        return $ret;
     }
 
     /**
@@ -1531,21 +1537,21 @@ if ($options[Erfurt_Store::USE_AC] == false) {
     public function transactionStart()
     {
         if (method_exists($this->_backendAdapter, 'transactionStart')) {
-            $thid->_backendAdapter->transactionStart();
+            $this->_backendAdapter->transactionStart();
         }
     }
 
     public function transactionCommit()
     {
         if (method_exists($this->_backendAdapter, 'transactionCommit')) {
-            $thid->_backendAdapter->transactionCommit();
+            $this->_backendAdapter->transactionCommit();
         }
     }
 
     public function transactionRollback()
     {
         if (method_exists($this->_backendAdapter, 'transactionRollback')) {
-            $thid->_backendAdapter->transactionRollback();
+            $this->_backendAdapter->transactionRollback();
         }
     }
 


### PR DESCRIPTION
If backend adapter supports transactions (e.g. Virtuoso via ODBC)
handle transactions in backend, otherwise ignore.

The addMultipleStatements method now automatically starts a transaction
if no transaction was already started.

Also the backend method returns a boolean value whether addition was
successfull and the store class passes this value to caller.

---

Jenkins is currently failing again (seems to be caused by doc stuff)... Here are the test results:

```
phpunit:
     [exec] PHPUnit 3.6.11 by Sebastian Bergmann.
     [exec] 
     [exec] Configuration read from /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/phpunit.xml.dist
     [exec] 
     [exec] ........................................................S......  63 / 615 ( 10%)
     [exec] .....................I......................................... 126 / 615 ( 20%)
     [exec] ............................................................... 189 / 615 ( 30%)
     [exec] ............................................................... 252 / 615 ( 40%)
     [exec] ............................................................... 315 / 615 ( 51%)
     [exec] ............................................................... 378 / 615 ( 61%)
     [exec] ............................................................... 441 / 615 ( 71%)
     [exec] ............................................................... 504 / 615 ( 81%)
     [exec] ............................................................... 567 / 615 ( 92%)
     [exec] ...............................................
     [exec] 
     [exec] Time: 01:33, Memory: 101.50Mb
     [exec] 
     [exec] There was 1 incomplete test:
     [exec] 
     [exec] 1) Erfurt_Sparql_ParserTest::testTokenizeFilter
     [exec] Issue #35 not yet fixed https://github.com/AKSW/Erfurt/issues/35
     [exec] 
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/Sparql/ParserTest.php:32
     [exec] /usr/bin/phpunit:46
     [exec] 
     [exec] --
     [exec] 
     [exec] 
     [exec] There was 1 skipped test:
     [exec] 
     [exec] 1) Erfurt_Rdf_MemoryModelTest::testHasO
     [exec] This test depends on "Erfurt_Rdf_MemoryModelTest::testAddAttributeCorrect" to pass.
     [exec] 
     [exec] /usr/bin/phpunit:46
     [exec] OK, but incomplete or skipped tests!
     [exec] Tests: 614, Assertions: 1087, Incomplete: 1, Skipped: 1.
     [exec] 
     [exec] Generating code coverage report in Clover XML format ... done
     [exec] 
     [exec] Generating code coverage report in HTML format ... done

phpunit-integration:
     [exec] PHPUnit 3.6.11 by Sebastian Bergmann.
     [exec] 
     [exec] Configuration read from /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/integration/phpunit.xml.dist
     [exec] 
     [exec] ........S...............S....SSSS...........S.SS..............
     [exec] 
     [exec] Time: 33 seconds, Memory: 37.75Mb
     [exec] 
     [exec] There were 9 skipped tests:
     [exec] 
     [exec] 1) Erfurt_AppIntegrationTest::testGetStoreWithCleanDatabase
     [exec] Skipped since other backend is under test.
     [exec] 
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:150
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:104
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/integration/Erfurt/AppIntegrationTest.php:113
     [exec] /usr/bin/phpunit:46
     [exec] 
     [exec] 2) Erfurt_Rdf_ModelIntegrationTest::testIsEditableWithZendDbAndAnonymousUserIssue774
     [exec] Skipped since other backend is under test.
     [exec] 
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:150
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/integration/Erfurt/Rdf/ModelIntegrationTest.php:143
     [exec] /usr/bin/phpunit:46
     [exec] 
     [exec] 3) Erfurt_Sparql_EngineDbIntegrationTest::testOdFmiLimitQueryWithZendDbIssue782WithLimit
     [exec] Skipped since other backend is under test.
     [exec] 
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:150
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/integration/Erfurt/Sparql/EngineDbIntegrationTest.php:13
     [exec] /usr/bin/phpunit:46
     [exec] 
     [exec] 4) Erfurt_Sparql_EngineDbIntegrationTest::testOdFmiLimitQueryWithZendDbIssue782WithoutLimit
     [exec] Skipped since other backend is under test.
     [exec] 
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:150
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/integration/Erfurt/Sparql/EngineDbIntegrationTest.php:60
     [exec] /usr/bin/phpunit:46
     [exec] 
     [exec] 5) Erfurt_Store_Adapter_EfZendDbIntegrationTest::testSparqlQuery
     [exec] Skipped since other backend is under test.
     [exec] 
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:150
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/integration/Erfurt/Store/Adapter/EfZendDbIntegrationTest.php:8
     [exec] /usr/bin/phpunit:46
     [exec] 
     [exec] 6) Erfurt_Store_Adapter_EfZendDbIntegrationTest::testSerialization
     [exec] Skipped since other backend is under test.
     [exec] 
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:150
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/integration/Erfurt/Store/Adapter/EfZendDbIntegrationTest.php:8
     [exec] /usr/bin/phpunit:46
     [exec] 
     [exec] 7) Erfurt_StoreIntegrationTest::testCheckSetupWithZendDb
     [exec] Skipped since other backend is under test.
     [exec] 
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:150
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:104
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/integration/Erfurt/StoreIntegrationTest.php:111
     [exec] /usr/bin/phpunit:46
     [exec] 
     [exec] 8) Erfurt_StoreIntegrationTest::testSparqlQueryWithCountQueryAndEmptyResultIssue174
     [exec] Skipped since other backend is under test.
     [exec] 
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:150
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/integration/Erfurt/StoreIntegrationTest.php:140
     [exec] /usr/bin/phpunit:46
     [exec] 
     [exec] 9) Erfurt_StoreIntegrationTest::testSparqlQueryWithCountAndFromIssue174
     [exec] Skipped since other backend is under test.
     [exec] 
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/unit/Erfurt/TestCase.php:150
     [exec] /var/lib/jenkins/jobs/Erfurt-Feature-Branches/workspace/tests/integration/Erfurt/StoreIntegrationTest.php:155
     [exec] /usr/bin/phpunit:46
     [exec] OK, but incomplete or skipped tests!
     [exec] Tests: 62, Assertions: 220, Skipped: 9.
     [exec] 
     [exec] Generating code coverage report in Clover XML format ... done
     [exec] 
     [exec] Generating code coverage report in HTML format ... done
```
