### PR TITLE
Reduce ord() calls in total by ~50% on plain OntoWiki start

### DIFF
--- a/library/Erfurt/Syntax/RdfParser/Adapter/Turtle.php
+++ b/library/Erfurt/Syntax/RdfParser/Adapter/Turtle.php
@@ -178,6 +178,7 @@ class Erfurt_Syntax_RdfParser_Adapter_Turtle extends Erfurt_Syntax_RdfParser_Ada
     
     protected function _parse($data)
     {
+        // Replace all whitespace by a single space to reduce chars to parse
         $this->_data = preg_replace('/\s+/', ' ', trim($data));
         $this->_dataLength = strlen($this->_data);
         $this->_pos  = 0;


### PR DESCRIPTION
Reduces the total amount of ord() calles from 152602 to 78150 on normal OntoWiki start, which reduces the total impact of _isWS in Turtle Parser by ~10% (from 28% to 17%)

Decreases load time on my system by 16%
