### PR TITLE
Reduce ord() calls in total by ~74% on plain start

### DIFF
--- a/library/Erfurt/Syntax/RdfParser/Adapter/Turtle.php
+++ b/library/Erfurt/Syntax/RdfParser/Adapter/Turtle.php
@@ -1007,12 +1007,13 @@ class Erfurt_Syntax_RdfParser_Adapter_Turtle extends Erfurt_Syntax_RdfParser_Ada
     
     protected function _isWS($c)
     {
+        $ca = ord($c);
         // ws ::= #x9 | #xA | #xD | #x20 | comment ('#' ( [^#xA#xD] )*)
         return (
-            ord($c) === 0x9  ||
-            ord($c) === 0xA  ||
-            ord($c) === 0xD  ||
-            ord($c) === 0x20 ||
+            $ca === 0x9  ||
+            $ca === 0xA  ||
+            $ca === 0xD  ||
+            $ca === 0x20 ||
             $c === '#'
         );   
     }


### PR DESCRIPTION
Reduces the total amount of ord() calles from 152602 to 39075 (26% left) on
normal OntoWiki start (news page, no model loaded), which reduces the
total impact of Turtle Parser's _isWS() by ~20% (from 32% to 10%)

Decreases load time on my system by 23%

Tests are successful!
