### PR TITLE
Fix RDF import on Windows

### DIFF
--- a/library/Erfurt/Store/Adapter/Virtuoso.php
+++ b/library/Erfurt/Store/Adapter/Virtuoso.php
@@ -1171,7 +1171,8 @@ class Erfurt_Store_Adapter_Virtuoso implements Erfurt_Store_Adapter_Interface, E
             $importSql = sprintf(
                 "CALL DB.DBA.%s(FILE_TO_STRING_OUTPUT('%s'), '%s', '%s')",
                 $importFunc,
-                $data,
+                // Escape backslashes ("\"), as these otherwise lead to errors on Windows systems.
+                addslashes($data),
                 $baseUri,
                 $graphUri
             );


### PR DESCRIPTION
This pull request fixes the RDF import via (temporary) files on Windows by escaping backslashes in the file path.
