### PR TITLE
Change statement sorting in tests

### DIFF
--- a/tests/unit/Erfurt/TestCase.php
+++ b/tests/unit/Erfurt/TestCase.php
@@ -213,7 +213,17 @@ class Erfurt_TestCase extends PHPUnit_Framework_TestCase
         self::assertEquals($expectedS, $gotS, $message);
 
         $sortFn = function(array $a, array $b) {
-            return strcmp($a['value'], $b['value']);
+            // The attributes that are used for sorting, in descending order.
+            $sortAttributes = array('value', 'type', 'xml:lang');
+            foreach ($sortAttributes as $key) {
+                $valueA = isset($a[$key]) ? $a[$key] : '';
+                $valueB = isset($b[$key]) ? $b[$key] : '';
+                $result = strcmp($valueA, $valueB);
+                if ($result !== 0) {
+                    return $result;
+                }
+            }
+            return 0;
         };
 
         foreach ($expectedS as $s) {


### PR DESCRIPTION
This modification changes the way statements are sorted in `assertStatementsEqual()` before comparison.

In the previous version the order was not clearly defined whenever statements had the same value, which led to failing tests due to different sorting.

This change adds some additional (secondary) sorting criteria to avoid these cases.
