### PR TITLE
Add information in case of Virtuoso connection failure

### DIFF
--- a/library/Erfurt/Store/Adapter/Virtuoso.php
+++ b/library/Erfurt/Store/Adapter/Virtuoso.php
@@ -297,7 +297,10 @@ class Erfurt_Store_Adapter_Virtuoso implements Erfurt_Store_Adapter_Interface, E
             }
             // success?
             if (false === $this->_connection) {
-                throw new Erfurt_Store_Adapter_Exception('Unable to connect to Virtuoso Universal Server via ODBC.');
+                $error   = error_get_last();
+                $message = 'Unable to connect to Virtuoso Universal Server via ODBC: ' . PHP_EOL
+                         . $error['message'];
+                throw new Erfurt_Store_Adapter_Exception($message);
             }
         }
 


### PR DESCRIPTION
This change adds the original error message to the exeption that is thrown when the ODBC connection to the Virtuoso server cannot be established.
This additional information should simplify debugging during Erfurt/OntoWiki setup.
