### PR TITLE
fix bug on count the deleted matching Statements

### DIFF
--- a/library/Erfurt/Store.php
+++ b/library/Erfurt/Store.php
@@ -562,25 +562,25 @@ class Erfurt_Store
             try {
                 $filter = '';
                 if (null !== $subject) {
-                    $filter = "FILTER (?s = <$subject>) .\n";
+                    $filter .= "FILTER (?s = <$subject>) .\n";
                 }
                 if (null !== $predicate) {
-                    $filter = "FILTER (?p = <$predicate>) .\n";
+                    $filter .= "FILTER (?p = <$predicate>) .\n";
                 }
                 if (null !== $object) {
                     if ($object['type'] == 'uri') {
                         $o = $object['value'];
-                        $filter = "FILTER (?o = <$o>) .\n";
+                        $filter .= "FILTER (?o = <$o>) .\n";
                     } else {
                         $o = $object['value'];
                         if (isset($object['datatype'])) {
                             $dt = $object['datatype'];
-                            $filter = "FILTER ((?o = \"$o\") && (datatype(?o) = <$dt>) .\n";
+                            $filter .= "FILTER ((?o = \"$o\") && (datatype(?o) = <$dt>) .\n";
                         } else if (isset($object['lang'])) {
                             $lang = $object['lang'];
-                            $filter = "FILTER ((?o = \"$o\") && (lang(?o) = \"$lang\") .\n";
+                            $filter .= "FILTER ((?o = \"$o\") && (lang(?o) = \"$lang\") .\n";
                         } else {
-                            $filter = "FILTER (?o = \"$o\") .\n";
+                            $filter .= "FILTER (?o = \"$o\") .\n";
                         }
                     }
                 }
@@ -597,7 +597,7 @@ EOF;
                     $sparql,
                     array(Erfurt_Store::RESULTFORMAT => Erfurt_Store::RESULTFORMAT_EXTENDED)
                 );
-                $ret = count($result);
+                $ret = count($result['results']['bindings']);
                 $stmts = array();
                 foreach ($result['results']['bindings'] as $row) {
                     $s = $row['s']['value'];


### PR DESCRIPTION
- the count is wrong because of overwriting the $filter variable and the wrong accessing of the $result variable
- if you use the subject, predicate and object for filter only the object will be filtered, because the filter of the subject and predicate was overwritten
- the second mistake is the accessing of the result array, counting the results with count($result) gives always 2 because the first level of the array is always setup with 'head' and 'result'. But to count the results statements you must count the bindings array ($result['results']['bindings'])
