### PR TITLE
added ldap authentification to Rdf auth adapter

### DIFF
--- a/library/Erfurt/config/default.ini
+++ b/library/Erfurt/config/default.ini
@@ -79,7 +79,9 @@ ac.user.mail          = "http://rdfs.org/sioc/ns#email"
 ac.user.superAdmin    = "http://ns.ontowiki.net/SysOnt/SuperAdmin"
 ac.user.anonymousUser = "http://ns.ontowiki.net/SysOnt/Anonymous"
 ac.user.recoveryHash  = "http://ns.ontowiki.net/SysOnt/recoveryHash"
-
+;; URIs for authentification via ldap
+ac.user.ldifdn              = "http://www.w3.org/2007/ont/ldif/dn"
+ac.user.authenticateViaLdap = "http://ns.ontowiki.net/SysOnt/authenticateViaLdap"
 ;; Schema URIs which define properties and classes for grouping
 ac.group.class        = "http://rdfs.org/sioc/ns#Usergroup"
 ac.group.membership   = "http://rdfs.org/sioc/ns#has_member"
@@ -189,6 +191,12 @@ cache.backend.sqlite.cache_db_complete_path         = "/tmp/ef_cache.sqlite"
 worker.enable  = true
 worker.backend = "Gearman"
 worker.servers = "127.0.0.1:4730"
+
+;;----------------------------------------------------------------------------;;
+;; LDAP                                                                    ;;
+;;----------------------------------------------------------------------------;;
+ldap.host = "localhost"
+ldap.protocolVersion = 3
 
 ;;----------------------------------------------------------------------------;;
 ;; Extension                                                                  ;;


### PR DESCRIPTION
To enable ldap authentification in Ontowiki, import these users into the System User Graph.
 
e.g. using https://github.com/FTeichmann/ldif2OntowikiUsers but the process is basically:

- add a predicate 'sysont:authenticateViaLdap' and set it to "true"^^xsd:boolean for the specified ldap user
- Virtuoso 6.1 AND Virtuoso 7 convert boolean true to "1"^^xsd:integer when saving the model and the Erfurt auth adapter reflects that behavior
- add a predicate 'http://www.w3.org/2007/ont/ldif/dn' to the literal of the ldap user dn as plain string
- configure the ldap connection in the respective chapter of the Erfurt configuration file
