### PR TITLE
Wrong predicates <lang> and <type> inRdf/ModelIntegrationTest

### DIFF
--- a/tests/integration/Erfurt/Rdf/ModelIntegrationTest.php
+++ b/tests/integration/Erfurt/Rdf/ModelIntegrationTest.php
@@ -191,12 +191,12 @@ class Erfurt_Rdf_ModelIntegrationTest extends Erfurt_TestCase
                         array('value' => $modelUri.'old', 'type' => 'literal'),
                         array('value' => $modelUri.'o2', 'type' => 'uri'),
                     ),
-                    'lang' => array(
+                    $modelUri.'lang' => array(
                         array('value' => 'LANG', 'type' => 'literal', 'lang' => 'en'),
                         array('value' => 'LANG', 'type' => 'literal', 'lang' => 'de'),
                         array('value' => 'LANG', 'type' => 'literal', 'lang' => 'mn'),
                     ),
-                    'type' => array(
+                    $modelUri.'type' => array(
                         array('value' => 'TYPE', 'type' => 'literal', 'datatype' => 'http://www.w3.org/2001/XMLSchema#string'),
                     ),
                 ),


### PR DESCRIPTION
The testRenameResource() in Rdf/ModelIntegrationTest.php test inserts several statements to test renaming and produces the following Sparql query:

```
INSERT INTO GRAPH <http://example.org/renameTest/> {<http://example.org/renameTest/> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .
    <http://example.org/renameTest/new> <http://example.org/renameTest/new> <http://example.org/renameTest/new> .
    <http://example.org/renameTest/new> <http://example.org/renameTest/p1> <http://example.org/renameTest/new> .
    <http://example.org/renameTest/new> <http://example.org/renameTest/p2> <http://example.org/renameTest/new> .
    <http://example.org/renameTest/new> <http://example.org/renameTest/p2> "http://example.org/renameTest/old" .
    <http://example.org/renameTest/new> <http://example.org/renameTest/p2> <http://example.org/renameTest/o2> .
    <http://example.org/renameTest/new> <lang> "LANG"@en .
    <http://example.org/renameTest/new> <lang> "LANG"@de .
    <http://example.org/renameTest/new> <lang> "LANG"@mn .
    <http://example.org/renameTest/new> <type> "TYPE"^^<http://www.w3.org/2001/XMLSchema#string> .
    <http://example.org/renameTest/s3> <http://example.org/renameTest/new> <http://example.org/renameTest/o3> .
    <http://example.org/renameTest/s4> <http://example.org/renameTest/p4> <http://example.org/renameTest/o4> .
    }
```

The test does not fail, because Virtuoso does not check the query. But I think the predicates `<lang>` and `<type>` are not correct. It should create statements like:
```
<http://example.org/renameTest/new> <http://example.org/renameTest/lang> "LANG"@en .
...
```

For this I just added `$modelUri` to the lang/type array keys as in the other keys. Otherwise this test fails for stardog (and maybe others) as backend.