### PR TITLE
Implement Stardog as Backend Adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,11 @@ default:
 	@echo "  test-unit .................... Run Erfurt unit tests"
 	@echo "  test-unit-cc ................. Same as above plus code coverage report"
 	@echo "  test-integration-virtuoso .... Run Erfurt integration tests with virtuoso"
-	@echo "  test-integration-virtuoso-cc . Same as above plus code coverage report"
+	@echo "  test-integration-virtuoso-cc . Same as above plus code coverage report"	
 	@echo "  test-integration-mysql ....... Run Erfurt integration tests with mysql"
 	@echo "  test-integration-mysql-cc .... Same as above plus code coverage report"
+	@echo "  test-integration-stardog ..... Run Erfurt integration tests with stardog"
+	@echo "  test-integration-stardog-cc .. Same as above plus code coverage report"
 	@echo "  test-clean ................... Clean test cache files, etc."
 	@echo "  ----------------------------------------------------------------------"
 	@echo "  codesniffer .................. Run CodeSniffer checks"
@@ -88,6 +90,12 @@ test-integration-mysql: directories
 test-integration-mysql-cc: directories
 	EF_STORE_ADAPTER=zenddb $(PHPUNIT) --testsuite "Erfurt Integration Tests" --coverage-html ./build/coverage-mysql
 
+test-integration-stardog: directories
+	EF_STORE_ADAPTER=stardog $(PHPUNIT) --testsuite "Erfurt Integration Tests"
+
+test-integration-stardog-cc: directories
+	EF_STORE_ADAPTER=stardog $(PHPUNIT) --testsuite "Erfurt Integration Tests" --coverage-html ./build/coverage-stardog
+
 test:
 	make test-unit
 	@echo ""
@@ -98,6 +106,10 @@ test:
 	@echo "-----------------------------------"
 	@echo ""
 	make test-integration-mysql
+	@echo ""
+	@echo "-----------------------------------"
+	@echo ""
+	make test-integration-stardog
 
 codesniffer:
 	$(PHPCS) -p

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=5.4.0",
         "semsol/arc2": "*",
         "zendframework/zendframework1": "1.*",
-        "easyrdf/easyrdf": "0.9.*"
+        "easyrdf/easyrdf": "0.9.*",
+        "guzzlehttp/guzzle": "5.3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         "php": ">=5.4.0",
         "semsol/arc2": "*",
         "zendframework/zendframework1": "1.*",
-        "easyrdf/easyrdf": "0.9.*",
-        "guzzlehttp/guzzle": "5.3.1"
+        "easyrdf/easyrdf": "0.9.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.5.*",

--- a/library/Erfurt/Store/Adapter/Stardog.php
+++ b/library/Erfurt/Store/Adapter/Stardog.php
@@ -1,0 +1,724 @@
+<?php
+/**
+ * This file is part of the {@link http://erfurt-framework.org Erfurt} project.
+ *
+ * @copyright Copyright (c) 2012-2016, {@link http://aksw.org AKSW}
+ * @license   http://opensource.org/licenses/gpl-license.php GNU General Public License (GPL)
+ */
+
+/**
+ * Stardog (http://stardog.com/) Adapter for the Erfurt Semantic Web Framework.
+ *
+ * Install Erfurt as described in https://github.com/AKSW/Erfurt/wiki/Getting-Started
+ * but use config.ini-dist-stardog as config.ini and adopt to your requirements
+ *
+ * To run stardog integration tests run: make test-integration-stardog
+ *
+ * Its tested with Stardog Version >=4.0.1 (Docker available: https://hub.docker.com/r/aksw/dld-store-stardog) and uses
+ * Zend_Http_Client in Erfurt_Store_Adapter_Stardog_ApiClient as HTTP Client
+ *
+ * @category Erfurt
+ * @package  Erfurt_Store_Adapter
+ * @author   Simeon Ackermann <amseon@web.de>
+ */
+class Erfurt_Store_Adapter_Stardog implements Erfurt_Store_Adapter_Interface, Erfurt_Store_Sql_Interface
+{
+    /**
+     * Prefix for blanknode identifiers.
+     * @var string
+     */
+    const BLANKNODE_PREFIX = 'nodeID://';
+
+    /**
+     * The low-level client that is used to interact with the triple store.
+     *
+     * @var \Erfurt_Store_Adapter_Stardog_ApiClient
+     */
+    protected $_apiClient = null;
+
+    /**
+     * The inner SQL adapter.
+     *
+     * @var \Erfurt_Store_Sql_Interface
+     */
+    protected $_sqlAdapter = null;
+
+    /**
+     * The available graphs in this store.
+     * @var array
+     */
+    protected $_graphs = null;
+
+    /**
+     * Model imports cache.
+     * @var array
+     */
+    protected $_importedModels = array();
+
+    /**
+     * Constructor.
+     *
+     * @throws Erfurt_Store_Adapter_Exception
+     */
+    public function __construct($adapterOptions = array())
+    {
+        // Access the connection in order to check whether it works.
+        $this->_apiClient = $this->connection($adapterOptions);
+
+        $dbs = $this->getDatabases();
+        if ( null === $dbs || ! in_array($adapterOptions['database'], $dbs) ) {
+            $this->createDatabase($adapterOptions['database']);
+        }
+
+        // Create sql Zend Adapter if Versioning is enabled
+        $efApp = Erfurt_App::getInstance(false);
+        if ( $efApp->getVersioning() !== false ) {
+            $this->_sqlAdapter = $this->sqlConnection();
+        }
+    }
+
+    /**
+     * Destructor
+     *
+     * @throws Erfurt_Exception
+     */
+    public function __destruct()
+    {
+    }
+
+    /**
+     *  New Guzzle Http Client to Stardog
+     *
+     * @param array Stardog Options from config file
+     * @return GuzzleHttp/Client
+     */
+    public function connection(array $options = array())
+    {
+        return $this->_apiClient ? $this->_apiClient : new Erfurt_Store_Adapter_Stardog_ApiClient($options);
+    }
+
+    /**
+     * Connect new SQL Adapter for versioning
+     *
+     * @throws Erfurt_Store_Adapter_Exception if initialization failed
+     * @return \Erfurt_Store_Sql_Interface
+     */
+    public function sqlConnection()
+    {
+        $app = Erfurt_App::getInstance(false);
+        $config = $app->getConfig();
+
+        // load Erfurt App with zenddb
+        $config->store->backend = 'zenddb';
+        $app->loadConfig($config);
+
+        try {
+            $efZend = $app->getStore();
+        } catch (Exception $e) {
+            throw new Erfurt_Store_Adapter_Exception(
+                'Stardog with versioning requires SQL store, ' .
+                'but initialization went wrong with message: '.$e->getMessage()
+            );
+        }
+
+        // reset Erfurt App Config to Stardog
+        $config->store->backend = 'stardog';
+        $app->loadConfig($config);
+
+        return $efZend;
+    }
+
+    /**
+     * Returns a list of exiisting databases
+     *
+     * @return array
+     */
+    protected function getDatabases()
+    {
+        return $this->_apiClient->getDatabases();
+    }
+
+    /**
+     * Creates an empty stardog database with the provided name
+     *
+     * @param string $database
+     */
+    protected function createDatabase($database)
+    {
+        $this->_apiClient->createDatabase($database);
+    }
+
+    /**
+     * Deletes the provided stardog database
+     *
+     * @param string $database
+     */
+    protected function dropDatabase($database)
+    {
+        $this->_apiClient->dropMyDatabase($database);
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function addStatement($graphUri, $subject, $predicate, array $objectSpec, array $options = array())
+    {
+        if ($objectSpec['type'] == 'uri') {
+            $object = '<' . $objectSpec['value'] . '>';
+        } else {
+            $object = $this->buildLiteralString(
+                $objectSpec['value'],
+                isset($objectSpec['datatype']) ? $objectSpec['datatype'] : null,
+                isset($objectSpec['lang']) ? $objectSpec['lang'] : null,
+                false
+            );
+        }
+
+        $data = '<' . $subject . '> <' . $predicate . '> ' . $object . ' .';
+        $this->_apiClient->import($data, $graphUri, Erfurt_Store_Adapter_Stardog_ApiClient::FORMAT_TURTLE);
+
+        if (defined('_EFDEBUG')) {
+            $logger = Erfurt_App::getInstance()->getLog();
+            $logger->debug('Add statement query: ' . PHP_EOL . $data);
+        }
+
+        return true;
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function addMultipleStatements($graphUri, array $statementsArray, array $options = array())
+    {
+        $triples = $this->buildTripleArray($statementsArray);
+        $this->_apiClient->import(implode($triples), $graphUri, Erfurt_Store_Adapter_Stardog_ApiClient::FORMAT_TURTLE);
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function deleteMatchingStatements($graphUri, $subject, $predicate, $object, array $options = array())
+    {
+        if (empty($graphUri)) {
+            throw new Erfurt_Store_Adapter_Exception('No graph URI given.');
+        }
+        $graphSpec     = '<' . (string)$graphUri . '>';
+        $subjectSpec   = $subject   ? '<' . (string)$subject . '>'   : '?s';
+        $predicateSpec = $predicate ? '<' . (string)$predicate . '>' : '?p';
+        $objectSpec = $this->getObjectSpec($object);
+
+        $deleteTriples = "";
+        $deletes = $this->sparqlQuery(
+            sprintf("SELECT * FROM %s WHERE { %s %s %s . }", $graphSpec, $subjectSpec, $predicateSpec, $objectSpec),
+            array('result_format' => 'extended')
+        );
+
+        if ( count($deletes['results']['bindings']) == 0 ) {
+            return 0;
+        }
+
+        foreach ($deletes['results']['bindings'] as $key => $triple) {
+            $deleteTriples .= isset($triple['s']) ? "<".$triple['s']['value']."> " : $subjectSpec . " ";
+            $deleteTriples .= isset($triple['p']) ? "<".$triple['p']['value']."> " : $predicateSpec . " ";
+            if ( isset($triple['o']) ) {
+                $objectSpec = $this->getObjectSpec($triple['o']);
+            }
+            $deleteTriples .= $objectSpec . "." . PHP_EOL;
+        }
+
+        $this->_apiClient->remove($deleteTriples, $graphUri, Erfurt_Store_Adapter_Stardog_ApiClient::FORMAT_TURTLE);
+
+        return count($deletes);
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function deleteMultipleStatements($graphUri, array $statementsArray)
+    {
+        $triples = $this->buildTripleArray($statementsArray);
+        $count = count($triples);
+
+        $this->_apiClient->remove(implode($triples), $graphUri, Erfurt_Store_Adapter_Stardog_ApiClient::FORMAT_TURTLE);
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function deleteModel($graphUri)
+    {
+        $this->_graphs = null;
+        return $this->_apiClient->query('DROP SILENT GRAPH <' . $graphUri . '>');;
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     * @todo test this, what needed for?
+     */
+    public function getBlankNodePrefix()
+    {
+        return self::BLANKNODE_PREFIX;
+    }
+
+    /**
+     * @see Erfurt_Store
+     */
+    public function getGraphsUsingResource($resourceUri)
+    {
+        $graphs = array();
+
+        $res = $this->sparqlQuery('SELECT DISTINCT ?graph { GRAPH ?graph { <'.$resourceUri.'> ?p ?o . } }');
+        if ($res) {
+            foreach ($res as $key => $value) {
+                $graphs[] = $value['graph'];
+            }
+        }
+
+        return $graphs;
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     * @todo Support Export
+     */
+    public function getSupportedExportFormats()
+    {
+        return array();
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     * @todo implement
+     */
+    public function exportRdf($graphUri, $serializationType = 'xml', $filename = null)
+    {
+        throw new Erfurt_Store_Adapter_Exception('RDF export not implemented yet.');
+    }
+
+    /**
+     * Return supportet import formats, but we dont need to support any,
+     * because \Erfurt_Store does all
+     *
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function getSupportedImportFormats()
+    {
+        // dont support any (Erfurt_Store does all)
+        return array();
+    }
+
+    /**
+     * Import RDF, will be done by addMultipleStatements() from \Erfurt_Store
+     *
+     * @see Erfurt_Store_Adapter_Interface
+     * @todo implement
+     */
+    public function importRdf($graphUri, $data, $type, $locator)
+    {
+        throw new Erfurt_Store_Adapter_Exception('RDF import not implemented yet.');
+    }
+
+    /**
+     * We dont need to init indexes or anything else...
+     *
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function init()
+    {
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function getAvailableModels()
+    {
+        if (null === $this->_graphs) {
+            $this->_graphs = array();
+
+            $rid = $this->_apiClient->query("SELECT DISTINCT ?g { GRAPH ?g { ?s ?p ?o . } }");
+            if ($rid) {
+                foreach ($rid['results']['bindings'] as $key => $value) {
+                    $this->_graphs[$value['g']['value']] = array('modelIri' => $value['g']['value']);
+                }
+            }
+        }
+        return $this->_graphs;
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function isModelAvailable($graphUri)
+    {
+        return array_key_exists((string)$graphUri, (array)$this->getAvailableModels());
+    }
+
+    /**
+     * Explicitly creates a new named graph.
+     *
+     * @param string $graphUri
+     * @param string $baseUri
+     * @return boolean
+     * @todo may allow creating empty graphs
+     */
+    public function createModel($graphUri, $type = Erfurt_Store::MODEL_TYPE_OWL)
+    {
+        // create empty graph
+        $createQuery = "CREATE SILENT GRAPH <$graphUri>";
+        $this->_apiClient->query($createQuery);
+
+        if ($type === Erfurt_Store::MODEL_TYPE_OWL) {
+            // add statement <graph> a owl:Ontology
+            $this->addStatement(
+                $graphUri, $graphUri, EF_RDF_TYPE, array('type'=>'uri','value'=>EF_OWL_ONTOLOGY)
+            );
+        } else {
+            // Bugfix for new empty graphs: add <graphUri> a Sysont:Model as new statement,
+            // otherwise getAvailableGraphs() will not recognize this empty graph
+            $this->addStatement(
+                $graphUri, $graphUri, EF_RDF_TYPE, array('type'=>'uri','value'=>'http://ns.ontowiki.net/SysOnt/Model')
+            );
+        }
+
+        // force reloading graphs next time
+        $this->_graphs = null;
+
+        return true;
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function getModel($modelIri)
+    {
+        if ( array_key_exists($modelIri, $this->_graphs) ) {
+            return new Erfurt_Rdf_Model($modelIri);
+        }
+        return null;
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function getNewModel($graphUri, $baseUri = '', $type = 'owl')
+    {
+        $this->createModel($graphUri);
+        return $this->getModel($graphUri);
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     *
+     * @return boolean|string|array is defined in _apiClient->query()
+     */
+    public function sparqlAsk($query)
+    {
+        return $this->_apiClient->query($query);
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     */
+    public function sparqlQuery($query, $options=array())
+    {
+        $resultFormat = isset($options[Erfurt_Store::RESULTFORMAT]) ?
+            $options[Erfurt_Store::RESULTFORMAT] :
+            Erfurt_Store::RESULTFORMAT_PLAIN;
+
+        // result format is extended by default, or boolean for ask
+        $results = $this->_apiClient->query((string)$query);
+
+        switch ($resultFormat) {
+            case Erfurt_Store::RESULTFORMAT_EXTENDED:
+                if ( is_bool($results) ) {
+                    $results = [ 'results' => [ 'bindings' => [ $results ] ] ];
+                } else {
+                    foreach ($results['results']['bindings'] as $rskey => $result) {
+                        foreach ($result as $rkey => $value) {
+                            if ( isset($value['xml:lang']) ) {
+                                $results['results']['bindings'][$rskey][$rkey]['lang'] = $value['xml:lang'];
+                                unset($results['results']['bindings'][$rskey][$rkey]['xml:lang']);
+                            }
+                        }
+                    }
+                }
+                break;
+
+            case Erfurt_Store::RESULTFORMAT_XML:
+                // @TODO
+                throw new Erfurt_Store_Adapter_Exception('Result Format XML not implemented yet.');
+
+            default: // RESULTFORMAT_PLAIN
+                if ( isset($results['results']['bindings']) ) {
+                    $results = $results['results']['bindings'];
+                    foreach ($results as $rskey => $result) {
+                        foreach ($result as $rkey => $value) {
+                            $results[$rskey][$rkey] = $value['value'];
+                        }
+                    }
+                }
+                break;
+        }
+
+        return $results ;
+    }
+
+    // ------------------------------------------------------------------------
+    // --- Public Methods (Erfurt_Store_Adapter_Sql_Interface) ----------------
+    // ------------------------------------------------------------------------
+
+    /**
+     * @see Erfurt_Store_Adapter_Sql_Interface
+     */
+    public function createTable($tableName, array $columns)
+    {
+        if ( $this->_sqlAdapter == null ) {
+            throw new Erfurt_Store_Adapter_Exception('SQL Adapter not connected.');
+        }
+
+        return $this->_sqlAdapter->createTable($tableName, $columns);
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Sql_Interface
+     */
+    public function lastInsertId()
+    {
+        if ( $this->_sqlAdapter == null ) {
+            throw new Erfurt_Store_Adapter_Exception('SQL Adapter not connected.');
+        }
+
+        return $this->_sqlAdapter->lastInsertId();
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Sql_Interface
+     */
+    public function listTables($prefix = '')
+    {
+        if ( $this->_sqlAdapter == null ) {
+            throw new Erfurt_Store_Adapter_Exception('SQL Adapter not connected.');
+        }
+
+        return $this->_sqlAdapter->listTables($prefix);
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Sql_Interface
+     */
+    public function sqlQuery($sqlQuery, $limit = PHP_INT_MAX, $offset = 0)
+    {
+        if ( $this->_sqlAdapter == null ) {
+            throw new Erfurt_Store_Adapter_Exception('SQL Adapter not connected.');
+        }
+
+        return $this->_sqlAdapter->sqlQuery($sqlQuery, $limit, $offset);
+    }
+
+    // ------------------------------------------------------------------------
+    // --- Public Helper Methods -----------------------------------------------------
+    // ------------------------------------------------------------------------
+
+    /**
+     * Builds a SPARQL-compatible literal string with long literals if necessary.
+     *
+     * @param string $value
+     * @param string|null $datatype
+     * @param string|null $lang
+     * @param boolean $longStringEnabled decides if the output can be a long string (""" """) or not
+     * @return string
+     */
+    public function buildLiteralString($value, $datatype = null, $lang = null, $longStringEnabled = true)
+    {
+        return Erfurt_Utils::buildLiteralString($value, $datatype, $lang, $longStringEnabled);
+    }
+
+    /**
+     * Calls specified function for every triple in N-Triples syntax out of an RDF/PHP array.
+     *
+     * @param $rdfPhpStatements A nested statement array
+     * @param $callback A function which will be called for each triple
+     */
+    public function buildTriple(array $rdfPhpStatements, $callback)
+    {
+        foreach ($rdfPhpStatements as $currentSubject => $predicates) {
+            foreach ($predicates as $currentPredicate => $objects) {
+                foreach ($objects as $currentObject) {
+                    // TODO: blank nodes
+                    $resource = '<' . trim($currentSubject) . '>';
+                    $property = '<' . trim($currentPredicate) . '>';
+
+                    if ($currentObject['type'] == 'uri') {
+                        $value = '<' . $currentObject['value'] . '>';
+                    } else {
+                        $value = $this->buildLiteralString(
+                            $currentObject['value'],
+                            array_key_exists('datatype', $currentObject) ? $currentObject['datatype'] : null,
+                            array_key_exists('lang', $currentObject) ? $currentObject['lang'] : null
+                        );
+                    }
+
+                    // add triple
+                    $callback(sprintf('%s %s %s .%s', $resource, $property, $value, PHP_EOL));
+                }
+            }
+        }
+    }
+
+    /**
+     * Builds an array of triples in N-Triples syntax out of an RDF/PHP array.
+     *
+     * @param $rdfPhpStatements A nested statement array
+     * @return array
+     */
+    public function buildTripleArray(array $rdfPhpStatements)
+    {
+        $triples = array();
+
+        $this->buildTriple(
+            $rdfPhpStatements,
+            function($triple) use(&$triples) {
+                $triples[] = $triple;
+            }
+        );
+
+        return $triples;
+    }
+
+    /**
+     * Builds a string of triples in N-Triples syntax out of an RDF/PHP array.
+     *
+     * @param $rdfPhpStatements A nested statement array
+     * @return string
+     */
+    public function buildTripleString(array $rdfPhpStatements)
+    {
+        $triples = '';
+
+        $this->buildTriple(
+            $rdfPhpStatements,
+            function($triple) use(&$triples) {
+                $triples .= $triple;
+            }
+        );
+
+        return $triples;
+    }
+
+    /**
+     * Creates an object specification as ?o or <object-uri> for sparql queries
+     *
+     * @param string|array(string->value) $object
+     * @return string
+     */
+    public function getObjectSpec($object)
+    {
+        if (null !== $object) {
+            if ($object['type'] == 'uri') {
+                $objectSpec = '<' . $object['value'] . '>';
+            } else {
+                $objectSpec = $this->buildLiteralString(
+                    $object['value'],
+                    true == isset($object['datatype']) ? $object['datatype'] : null,
+                    true == isset($object['lang']) ? $object['lang'] : null,
+                    false
+                );
+            }
+        } else {
+            $objectSpec = '?o';
+        }
+
+        return $objectSpec;
+    }
+
+    /**
+     * @see Erfurt_Store_Adapter_Interface
+     * @todo Rename countMatchingStatements
+     */
+    public function countWhereMatches($graphUris, $whereSpec, $countSpec, $distinct = false)
+    {
+        if (empty($graphUris)) {
+            throw new Erfurt_Store_Adapter_Exception('No graph URI given.');
+        }
+        if ($distinct) {
+            $distinct = "DISTINCT";
+        } else {
+            $distinct = "";
+        }
+
+        // more error save
+        if ($countSpec == '?*') {
+            $countSpec = '*';
+        }
+
+        $fromSpec = implode('> FROM <', (array)$graphUris);
+        $countQuery = sprintf(
+            'SELECT COUNT %s (%s) FROM <%s> %s',
+            $distinct,
+            $countSpec,
+            $fromSpec,
+            $whereSpec
+        );
+
+        // @TODO test this
+        if ($rid = $this->_apiClient->query($countQuery)) {
+            $count = (int)$rid['results']['bindings'];
+            return $count;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Recursively gets owl:imported model IRIs starting with $modelUri as root.
+     *
+     * @param string $modelUri
+     */
+    public function getImportsClosure($modelUri)
+    {
+        $queryCache = Erfurt_App::getInstance()->getQueryCache();
+
+        if (!array_key_exists($modelUri, $this->_importedModels)) {
+            $models = array();
+            $result = array(
+                // mock first result
+                array('o' => $modelUri)
+            );
+            do {
+                $from    = '';
+                $filter   = array();
+                foreach ($result as $row) {
+                    $from    .= ' FROM <' . $row['o'] . '>' . PHP_EOL;
+                    $filter[] = 'sameTerm(?model, <' . $row['o'] . '>)';
+
+                    // ensure no model is added twice
+                    if (!array_key_exists($row['o'], $models)) {
+                        $models[$row['o']] = $row['o'];
+                    }
+                }
+                $query = '
+                    SELECT ?o' .
+                    $from . '
+                    WHERE {
+                        ?model <' . EF_OWL_NS . 'imports> ?o.
+                        FILTER (' . implode(' || ', $filter) . ')
+                    }';
+
+                $result = $queryCache->load($query, Erfurt_Store::RESULTFORMAT_PLAIN);
+                if ($result == Erfurt_Cache_Frontend_QueryCache::ERFURT_CACHE_NO_HIT) {
+                    $startTime = microtime(true);
+                    $result = $this->sparqlQuery($query);
+                    $duration = microtime(true) - $startTime;
+                    $queryCache->save($query, Erfurt_Store::RESULTFORMAT_PLAIN, $result, $duration);
+                }
+            } while ($result);
+
+            // unset root node
+            unset($models[$modelUri]);
+
+            // cache result
+            $this->_importedModels[$modelUri] = array_keys($models);
+        }
+        return $this->_importedModels[$modelUri];
+    }
+}

--- a/library/Erfurt/Store/Adapter/Stardog/ApiClient.php
+++ b/library/Erfurt/Store/Adapter/Stardog/ApiClient.php
@@ -1,0 +1,484 @@
+<?php
+/**
+ * This file is part of the {@link http://erfurt-framework.org Erfurt} project.
+ *
+ * @copyright Copyright (c) 2012-2016, {@link http://aksw.org AKSW}
+ * @license   http://opensource.org/licenses/gpl-license.php GNU General Public License (GPL)
+ */
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Command\Guzzle\GuzzleClient;
+use GuzzleHttp\Command\Guzzle\Description;
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * Uses the low-level API client to provide a more advanced interface
+ * that is used to read and manipulate data in a Stardog database.
+ *
+ * @author   Simeon Ackermann <amseon@web.de>
+ * @author Matthias Molitor <molitor@informatik.uni-bonn.de>
+ * @since 08.03.14
+ */
+class Erfurt_Store_Adapter_Stardog_ApiClient extends Client
+{
+    /**
+     * Identifiers for the different import formats.
+     */
+    const FORMAT_RDF_XML  = 'application/rdf+xml';
+    const FORMAT_TURTLE   = 'text/turtle';
+    const FORMAT_NTRIPLES = 'text/plain';
+    const FORMAT_TRIG     = 'application/x-trig';
+    const FORMAT_TRIX     = 'application/trix';
+    const FORMAT_NQUADS   = 'text/x-nquads';
+    const FORMAT_JSON_LD  = 'application/ld+json';
+
+    /**
+     * The low-level client that is used to interact with the triple store.
+     *
+     * @var GuzzleHttp/Client
+     */
+    protected $_apiClient = null;
+
+    /**
+     * ID of the running transaction or null if no transaction is active.
+     *
+     * @var string|null
+     */
+    protected $_runningTransaction = null;
+
+    /**
+     * IDs of transactions that have been opened, but not committed or
+     * rolled back yet.
+     *
+     * @var array(string)
+     */
+    protected $_pendingTransactions = array();
+
+    /**
+     * The name of the database that is managed by this setup.
+     *
+     * @var string
+     */
+    protected $_database = null;
+
+    /**
+     * Creates a data access client that uses the provided API client.
+     *
+     * @param Erfurt_Store_Adapter_Stardog_ApiClient $client
+     * @param array $adapterOptions
+     */
+    public function __construct(array $adapterOptions = array())
+    {
+        $this->_apiClient = $this->init($adapterOptions);
+
+        register_shutdown_function(array($this, 'rollbackPendingTransactions'));
+    }
+
+    /**
+     * Initial connection to Stardog with params from config
+     *
+     * @param array $options
+     * @return GuzzleHttp/Client
+     */
+    public function init(array $options = array())
+    {
+        $client = $this->_apiClient;
+        if ( ! $client ) {
+
+            if ( ! isset($options['base_url']) ) {
+                throw new Erfurt_Store_Adapter_Exception('Your config.ini lacks a store.stardog.base_url parameter.');
+            }
+
+            if ( ! isset($options['database']) ) {
+                throw new Erfurt_Store_Adapter_Exception('Your config.ini lacks a store.stardog.database parameter.');
+            } else {
+                $this->_database = $options['database'];
+            }
+
+            if (isset($options['username']) && isset($options['password'])) {
+                $options['defaults'] = [ 'auth' => [ (string)$options['username'], (string)$options['password'] ] ];
+            }
+
+            $client = new Client($options);
+        }
+        return $client;
+    }
+
+    /**
+     * Returns a list of exiisting databases
+     *
+     * @return array
+     */
+    public function getDatabases()
+    {
+        $requestOptions = [
+            'headers' => [ 'accept' => 'application/json' ]
+        ];
+
+        $res = $this->_apiClient->get('/admin/databases', $requestOptions);
+        $res = json_decode($res->getBody(), true);
+        return $res['databases'];
+    }
+
+    /**
+     * Creates an empty database with the provided name.
+     *
+     * @param string $database
+     */
+    public function createDatabase($database)
+    {
+        $boundary = 'b' . md5(uniqid('', true));
+        $definition = array(
+            'dbname'  => $database,
+            'options' => new stdClass(),
+            'files'   => array()
+        );
+        $definitionAsJson = json_encode($definition);
+
+        $body = "--$boundary\r\n"
+              . "Content-Disposition: form-data; name=\"definition\"\"\r\n"
+              . "Content-Type: application/json\r\n"
+              . "\r\n"
+              . "$definitionAsJson\r\n"
+              . "--$boundary--\r\n";
+
+        $requestOptions = [
+            'body' => $body,
+            'headers' => [ 'Content-Type' => 'multipart/form-data; boundary=' . $boundary ]
+        ];
+
+        $this->_apiClient->post('/admin/databases', $requestOptions);
+    }
+
+    /**
+     * Deletes the provided databse
+     *
+     * @param string $database
+     */
+    public function dropMyDatabase($database)
+    {
+        $requestOptions = [
+            'headers' => [ 'accept' => 'application/json' ]
+        ];
+        $this->_apiClient->delete('/admin/databases/' . $database, $requestOptions);
+    }
+
+    /**
+     * Executes a SPARQL query and returns the result.
+     *
+     * Any type of SPARQL query is accepted (SELECT, ASK, UPDATE, DELETE, ...).
+     * The returned result depends on the query type. No conversion or normalization
+     * is applied.
+     *
+     * @param string $sparqlQuery
+     * @return array|SimpleXMLElement
+     */
+    public function query($sparqlQuery)
+    {
+        $requestOptions = [
+            'body' => [ 'query' => $sparqlQuery ],
+            'headers' => [ 'accept' => 'application/sparql-results+json' ]
+        ];
+
+        try {
+            $res = $this->_apiClient->post($this->_database . '/query', $requestOptions);
+        } catch (RequestException $e) {
+            if ($e->hasResponse()) {
+                $message = sprintf('SPARQL Error: %s with query: %s', $e->getResponse(), $sparqlQuery);
+            } else {
+                $message = sprintf('SPARQL Error with query: %s', $sparqlQuery);
+            }
+            throw new Erfurt_Store_Adapter_Exception($message);
+        } catch (Exception $e) {
+            throw new Erfurt_Store_Adapter_Exception('SQL Error with query:' . $sparqlQuery);
+        }
+
+        if ( empty($res->getBody()) ) {
+            return 'OK' === $res->getReasonPhrase() ? true : false;
+        } else {
+            $res = json_decode($res->getBody(), true);
+
+            if ( isset($res['boolean']) ) {
+                return (boolean)$res['boolean'];
+            }
+
+            return $res;
+        }
+    }
+
+    /**
+     * Imports the provided data.
+     *
+     * The provided triple data must be a string that fulfills the requirements
+     * of the given format.
+     * Optionally an import graph can be provided. If no graph is given, then the
+     * data will be imported into the default graph.
+     * Please note that formats that rely on quads should not provide a graph.
+     *
+     * Example:
+     *
+     *     $data = '<http://example.org/subject> <http://example.org/predicate> <http://example.org/object> .';
+     *     $client->import(
+     *         $data,
+     *         'http://example.org/target-graph',
+     *         Erfurt_Store_Adapter_Stardog_DataAccessClient::FORMAT_NTRIPLES
+     *     );
+     *
+     * @param string $data
+     * @param string|null $graph
+     * @param string $format
+     */
+    public function import($data, $graph = null, $format = self::FORMAT_TURTLE)
+    {
+        $arguments = array(
+            'triples'     => $data,
+            'inputFormat' => $format
+        );
+        if ($graph !== null) {
+            $arguments['graph-uri'] = $graph;
+        }
+        /* The add operation must be wrapped into a transaction.
+        transactional() is used to start a transaction if that did not already happen.
+        The transaction ID is passed by reference as it will only be available when
+        the execution of transactional() starts. */
+        $apiClient   = $this->_apiClient;
+        $transaction = &$this->_runningTransaction;
+
+        $this->transactional(
+            function () use ($apiClient, &$transaction, $arguments) {
+            $arguments['transaction-id'] = $transaction;
+            $this->mutativeOperation('/add', $arguments);
+            }
+        );
+    }
+
+    /**
+     * Removes the given set of triples.
+     *
+     * This method works in the same way as import().
+     *
+     * Example:
+     *
+     *     $data = '<http://example.org/subject> <http://example.org/predicate> <http://example.org/object> .';
+     *     $client->delete(
+     *         $data,
+     *         'http://example.org/affected-graph'
+     *         Erfurt_Store_Adapter_Stardog_DataAccessClient::FORMAT_NTRIPLES,
+     *     );
+     *
+     * @param string $data
+     * @param string|null $graph
+     * @param string $format
+     */
+    public function remove($data, $graph = NULL, $format = self::FORMAT_TURTLE)
+    {
+        $arguments = array(
+            'triples'     => $data,
+            'inputFormat' => $format
+        );
+        if ($graph !== null) {
+            $arguments['graph-uri'] = $graph;
+        }
+        // Passes the triples that must be deleted and manages the transaction that
+        // is required for the remove() call (analog to import()).
+        $apiClient   = $this->_apiClient;
+        $transaction = &$this->_runningTransaction;
+
+        $this->transactional(
+            function () use ($apiClient, &$transaction, $arguments) {
+            $arguments['transaction-id'] = $transaction;
+            $this->mutativeOperation('/remove', $arguments);
+            }
+        );
+    }
+
+    /**
+     * Executes the provided callback within a transaction.
+     *
+     * The callback receives the DataAccessClient as argument.
+     * If another transaction is requested within such a callback,
+     * then the existing transaction will be used. No commit
+     * or rollback will be performed when the sub-transaction
+     * finishes as the main transactional call is responsible
+     * for that.
+     *
+     * @param callback $callback
+     * @throws InvalidArgumentException if no valid callback is passed.
+     * @throws Exception Any error from the executed callback.
+     */
+    public function transactional(callable $callback)
+    {
+        if ($this->inTransaction()) {
+            /* A transaction is already active, therefore, this execution of transactional()
+            is not responsible for transaction management. */
+            call_user_func($callback, $this);
+            return;
+        }
+        $this->beginTransaction();
+        try {
+            call_user_func($callback, $this);
+            $this->commit();
+        } catch (Exception $e) {
+            try {
+                $this->rollback();
+            } catch (\Exception $rollbackException) {
+                $message = 'Transaction rollback failed: ' . PHP_EOL . $rollbackException;
+                throw new RuntimeException($message, 0, $e);
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Adds the current transaction ID to the given operation arguments.
+     *
+     * Does not change the arguments if no transaction is running.
+     *
+     * @param array(string=>string) $arguments
+     * @return array(string=>string)
+     */
+    protected function withTransaction(array $arguments)
+    {
+        if (!$this->inTransaction()) {
+            return $arguments;
+        }
+        $arguments['transaction-id'] = $this->_runningTransaction;
+        return $arguments;
+    }
+
+    /**
+     * Starts a new transaction.
+     *
+     * @return string $id
+     */
+    protected function beginTransaction()
+    {
+        $id = $this->databaseOperation('POST', '/transaction/begin');
+        $this->_runningTransaction = (string) $id;
+        $this->_pendingTransactions[] = (string) $id;
+        return $id;
+    }
+
+    /**
+     * Commits the running transaction.
+     */
+    protected function commit()
+    {
+        $transactionId = $this->withTransaction(array())['transaction-id'];
+        $this->transactionalOperation($transactionId, '/transaction/commit/');
+        $this->removePendingTransaction($transactionId);
+        $this->_runningTransaction = null;
+    }
+
+    /**
+     * Performs a running for the current transaction.
+     */
+    protected function rollback()
+    {
+        $id = $this->withTransaction(array())['transaction-id'];
+        $this->transactionalOperation($id, '/transaction/rollback/');
+        if (in_array($id, $this->_pendingTransactions)) {
+            unset($this->_pendingTransactions[array_search($id, $this->_pendingTransactions)]);
+        }
+        $this->_runningTransaction = null;
+    }
+
+    /**
+     * Checks if the client is currently in a transaction.
+     *
+     * @return boolean
+     */
+    protected function inTransaction()
+    {
+        return $this->_runningTransaction !== null;
+    }
+
+    /**
+     * Removes the provided ID from the list of pending transactions.
+     *
+     * @param string $id
+     */
+    protected function removePendingTransaction($id)
+    {
+        if (in_array($id, $this->_pendingTransactions)) {
+            unset($this->_pendingTransactions[array_search($id, $this->_pendingTransactions)]);
+        }
+    }
+
+    /**
+     * Rolls back any transaction that is still pending.
+     */
+    public function rollbackPendingTransactions()
+    {
+        if (count($this->_pendingTransactions) === 0) {
+            return;
+        }
+        foreach ($this->_pendingTransactions as $id) {
+            $this->transactionalOperation($id, '/transaction/rollback/');
+        }
+        $this->_pendingTransactions = array();
+    }
+
+    /**
+     * Operation against the database
+     *
+     * @param string $httpMethod (POST|GET)
+     * @param string $uri
+     * @return string Transaction Id
+     */
+    protected function databaseOperation($httpMethod, $uri)
+    {
+        $request = $this->_apiClient->createRequest($httpMethod, $this->_database . $uri);
+        $response = $this->_apiClient->send($request);
+        return $response->getBody();
+    }
+
+    /**
+     * Operation that requires transaction
+     *
+     * @param string $transactionId
+     * @param string $uri
+     * @return string|array
+     */
+    protected function transactionalOperation($transactionId, $uri)
+    {
+        $res = $this->_apiClient->post($this->_database . $uri . $transactionId);
+        return $res->getBody();
+    }
+
+    /**
+     * Operation that uses a set of triples to change the database
+     *
+     * @param string $uri
+     * @param array(string->value) $arguments
+     * @throws Erfurt_Store_Adapter_Exception if no valid triple set was passed
+     * @return string|array|boolean Result set, depends on request
+     */
+    protected function mutativeOperation(
+        $uri, array $arguments = array('triples' => '', 'graph-uri' => NULL, 'inputFormat' => FORMAT_TURTLE)
+    )
+    {
+        $uri = $this->_database . '/' . $arguments['transaction-id'] . $uri;
+
+        $requestOptions = [
+            'body' => $arguments['triples'],
+            'query' => ['graph-uri' => $arguments['graph-uri']],
+            'headers' => [ 'Content-Type' => $arguments['inputFormat'] ]
+        ];
+
+        try {
+            $res = $this->_apiClient->post($uri, $requestOptions);
+        } catch (RequestException $e) {
+            if ($e->hasResponse()) {
+                $message = sprintf("SPARQL Error: \n %s with triples: %s", $e->getResponse(), $arguments['triples']);
+            } else {
+                $message = sprintf('SPARQL Error with triples: %s', $arguments['triples']);
+            }
+            throw new Erfurt_Store_Adapter_Exception($message);
+        } catch (Exception $e) {
+            throw new Erfurt_Store_Adapter_Exception('SQL Error with triples:' . $arguments['triples']);
+        }
+
+        return $res->getBody();
+    }
+}

--- a/library/Erfurt/config.ini-dist-stardog
+++ b/library/Erfurt/config.ini-dist-stardog
@@ -1,0 +1,26 @@
+[private]
+
+;;----------------------------------------------------------------------------;;
+;; Database Connection Settings                                               ;;
+;;----------------------------------------------------------------------------;;
+
+store.backend = stardog ;
+
+versioning = true ; if versioning is true you need to config ZendDB as additional versioning-store (see below)
+
+;
+; Stardog backend
+;
+store.stardog.base_url   = "http://localhost:5820"
+store.stardog.username   = "admin"
+store.stardog.password   = "admin"
+store.stardog.database   = "erfurt"
+
+;
+; ZendDB
+;
+store.zenddb.dbname   = erfurt
+store.zenddb.username = root
+store.zenddb.password = password
+store.zenddb.dbtype   = mysql     ; mysql
+store.zenddb.host     = localhost ; default is localhost

--- a/tests/integration/Erfurt/Store/Adapter/StardogIntegrationTest.php
+++ b/tests/integration/Erfurt/Store/Adapter/StardogIntegrationTest.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * This file is part of the {@link http://erfurt-framework.org Erfurt} project.
+ *
+ * @copyright Copyright (c) 2014-2016, {@link http://aksw.org AKSW}
+ * @license   http://opensource.org/licenses/gpl-license.php GNU General Public License (GPL)
+ */
+
+class Erfurt_Store_Adapter_StardogIntegrationTest extends Erfurt_TestCase
+{
+    /** @var Erfurt_Store_Adapter_Stardog */
+    public $fixture = null;
+
+    private $_resourcesDirectory = null;
+
+    public function setUp()
+    {
+        $this->markTestNeedsStardog();
+        $config = $this->getTestConfig()->store->stardog->toArray();
+        $this->fixture = new Erfurt_Store_Adapter_Stardog($config);
+
+        $this->_resourcesDirectory = realpath(dirname(dirname(dirname(__FILE__)))) . '/_files/';
+    }
+
+    public function testInstantiation()
+    {
+        $this->assertSame('Erfurt_Store_Adapter_Stardog', get_class($this->fixture));
+    }
+
+    public function testAddStatementWithUriObject()
+    {
+        $g = 'http://example.com/';
+        $s = 'http://example.com/';
+        $p = 'http://example.com/property1';
+
+        $oSpec = array(
+            'value' => 'http:/example.com/resource1',
+            'type' => 'uri'
+        );
+
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $oSpec));
+    }
+
+    public function testAddStatementsWithLiteralObject()
+    {
+        $g = 'http://example.com/';
+        $s = 'http://example.com/';
+        $p = 'http://example.com/property1';
+
+        $options = array();
+        $o = array('type' => 'literal');
+
+        // short literal
+        $o['value'] = 'short literal';
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // short literal containing double quote
+        $o['value'] = 'short "literal"';
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // short literal containing escaped double quote
+        $o['value'] = 'short \"literal\"';
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // short literal containing single quote
+        $o['value'] = "short 'literal'";
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // short literal containing escaped single quote
+        $o['value'] = "short \'literal\'";
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // long literal 1
+        $o['value'] = "long \n literal 1";
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // long literal 2
+        $o['value'] = "long
+        literal 2";
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // long literal 3
+        $o['value'] = "long \r\n literal 2";
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // Unix path literal
+        $o['value'] = '/usr/local/bin/virtuoso-t';
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // Windows path literal
+        $o['value'] = "C:\\\\Programme\\\\Conficker\\\\FormatHardDrive.exe";
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // Windows path literal
+        $o['value'] = '"C:\\\\Program Files\\\\Conficker\\\\FormatHardDrive.exe"';
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // boolean literal with numerical representation
+        $o['value']  = '1';
+        $pA = 'http://example.com/booleanProperty1';
+        $this->assertNotEquals(
+            false,
+            $this->fixture->addStatement(
+                $g, $s, $pA, $o,
+                array_merge(
+                    $options,
+                    array('literal_datatype' => 'http://www.w3.org/2001/XMLSchema#boolean')
+                )
+            )
+        );
+
+        // boolean literal with string representation
+        $o['value']  = 'true';
+        $pA = 'http://example.com/booleanProperty2';
+        $this->assertNotEquals(
+            false,
+            $this->fixture->addStatement(
+                $g, $s, $pA, $o,
+                array_merge(
+                    $options,
+                    array('literal_datatype' => 'http://www.w3.org/2001/XMLSchema#boolean')
+                )
+            )
+        );
+
+        // Vakantieland tests
+
+        // vakantieland string 1 (unescaped)
+        $o['value'] = 'verhuisd onder ? dak, nu "Apeldoorns Museum"';
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // vakantieland string 1 (escaped) -- Virtuoso will remove escaping
+        $o['value'] = 'verhuisd onder ? dak, nu \"Apeldoorns Museum\"';
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // vakantieland string 2
+        $o['value'] = "per persoon: 113.45 &euro;<br/>CJP: 0 &euro;";
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // vakantieland string 3
+        $o['value'] = "van.reekum";
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // vakantieland string 4
+        $o['value'] = "http://www.apeldoorn.org/vanreekum/";
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+
+        // vakantieland string 5
+        $o['value'] =
+            '"In de Tinnen Wonderwereld" is niet langer wegens het overlijden van E. Spandauw (5-10-2000), '.
+            'de oprichter en uitbater van het museum. http://members.tripod.com/~tingieten/';
+        $this->assertNotEquals(false, $this->fixture->addStatement($g, $s, $p, $o, $options));
+    }
+
+    public function testBuildLiteralString()
+    {
+        $value    = 'Literal';
+        $datatype = 'http://www.w3.org/2001/XMLSchema#string';
+        $expected = '"Literal"^^<http://www.w3.org/2001/XMLSchema#string>';
+        $this->assertEquals($expected, $this->fixture->buildLiteralString($value, $datatype, null));
+
+        $value    = "Literal \n with newline";
+        $datatype = 'http://www.w3.org/2001/XMLSchema#string';
+        $expected = "\"\"\"Literal \n with newline\"\"\"^^<http://www.w3.org/2001/XMLSchema#string>";
+        $this->assertEquals($expected, $this->fixture->buildLiteralString($value, $datatype, null));
+
+        $value    = 'Literal';
+        $lang     = 'de';
+        $expected = '"Literal"@de';
+        $this->assertEquals($expected, $this->fixture->buildLiteralString($value, null, $lang));
+
+        $value    = 'Over the past 3 years, the semantic web activity has gained momentum with the widespread '.
+            'publishing of structured data as RDF. The Linked Data paradigm has therefore evolved from a practical '.
+            'research idea into a very promising candidate for addressing one of the biggest challenges in the area '.
+            'of intelligent information management: the exploitation of the Web as a platform for data and '.
+            'information integration in addition to document search. To translate this initial success into a '.
+            'world-scale disruptive reality, encompassing the Web 2.0 world and enterprise data alike, the following '.
+            'research challenges need to be addressed: improve coherence and quality of data published on the Web, '.
+            'close the performance gap between relational and RDF data management, establish trust on the Linked Data '.
+            'Web and generally lower the entrance barrier for data publishers and users. With partners among those '.
+            'who initiated and strongly supported the Linked Open Data initiative, the LOD2 project aims at tackling '.
+            'these challenges by developing:'.PHP_EOL.
+            '<ol>'.PHP_EOL.
+            '<li>enterprise-ready tools and methodologies for exposing and managing very large amounts of structured '.
+                'information on the Data Web,</li>'.PHP_EOL.
+            '<li>a testbed and bootstrap network of high-quality multi-domain, multi-lingual ontologies from sources '.
+                'such as Wikipedia and OpenStreetMap.</li>'.PHP_EOL.
+            '<li>algorithms based on machine learning for automatically interlinking and fusing data from the '.
+                'Web.</li>'.PHP_EOL.
+            '<li>standards and methods for reliably tracking provenance, ensuring privacy and data security as well '.
+                'as for assessing the quality of information.</li>'.PHP_EOL.
+            '<li>adaptive tools for searching, browsing, and authoring of Linked Data.</li>'.PHP_EOL.
+            '</ol>'.PHP_EOL.
+            'We will integrate and syndicate linked data with large-scale, existing applications and showcase the '.
+            'benefits in the three application scenarios of media & publishing, corporate data intranets and '.
+            'eGovernment. The resulting tools, methods and data sets have the potential to change the Web as we '.
+            'know it today.';
+
+        $expected = '"""Over the past 3 years, the semantic web activity has gained momentum with the widespread '.
+            'publishing of structured data as RDF. The Linked Data paradigm has therefore evolved from a practical '.
+            'research idea into a very promising candidate for addressing one of the biggest challenges in the area '.
+            'of intelligent information management: the exploitation of the Web as a platform for data and '.
+            'information integration in addition to document search. To translate this initial success into a '.
+            'world-scale disruptive reality, encompassing the Web 2.0 world and enterprise data alike, the following '.
+            'research challenges need to be addressed: improve coherence and quality of data published on the Web, '.
+            'close the performance gap between relational and RDF data management, establish trust on the Linked '.
+            'Data Web and generally lower the entrance barrier for data publishers and users. With partners among '.
+            'those who initiated and strongly supported the Linked Open Data initiative, the LOD2 project aims at '.
+            'tackling these challenges by developing:'.PHP_EOL.
+            '<ol>'.PHP_EOL.
+            '<li>enterprise-ready tools and methodologies for exposing and managing very large amounts of structured '.
+                'information on the Data Web,</li>'.PHP_EOL.
+            '<li>a testbed and bootstrap network of high-quality multi-domain, multi-lingual ontologies from sources '.
+                'such as Wikipedia and OpenStreetMap.</li>'.PHP_EOL.
+            '<li>algorithms based on machine learning for automatically interlinking and fusing data from '.
+                'the Web.</li>'.PHP_EOL.
+            '<li>standards and methods for reliably tracking provenance, ensuring privacy and data security as well '.
+                'as for assessing the quality of information.</li>'.PHP_EOL.
+            '<li>adaptive tools for searching, browsing, and authoring of Linked Data.</li>'.PHP_EOL.
+            '</ol>'.PHP_EOL.
+            'We will integrate and syndicate linked data with large-scale, existing applications and showcase the '.
+            'benefits in the three application scenarios of media & publishing, corporate data intranets and '.
+            'eGovernment. The resulting tools, methods and data sets have the potential to change the Web as we '.
+            'know it today."""';
+
+        $this->assertEquals($expected, $this->fixture->buildLiteralString($value));
+    }
+
+    public function testBuildTripleString()
+    {
+        $statementsA = array(
+            'http://example.com/1' => array(
+                'http://example.com/2' => array(
+                    array('type' => 'uri', 'value' => 'http://example.com/3'),
+                    array('type' => 'literal', 'value' => 'literal 1'),
+                    array('type' => 'literal', 'value' => 'literal 2', 'lang' => 'en'),
+                    array('type' => 'literal', 'value' => 'literal 3', 'datatype' => 'http://example.com/4'),
+                    array('type' => 'literal', 'value' => "literal\n4")
+                )
+            )
+        );
+        $expectedA = <<<EOT
+<http://example.com/1> <http://example.com/2> <http://example.com/3> .
+<http://example.com/1> <http://example.com/2> "literal 1" .
+<http://example.com/1> <http://example.com/2> "literal 2"@en .
+<http://example.com/1> <http://example.com/2> "literal 3"^^<http://example.com/4> .
+<http://example.com/1> <http://example.com/2> """literal\n4""" .
+
+EOT;
+
+        $resultA = $this->fixture->buildTripleString($statementsA);
+        // The Triple string uses platform dependent line endings. Therefore, the line endings must be normalized
+        // before they are compared (the line endings in this file are always in Unix format).
+        $resultA = str_replace(PHP_EOL, "\n", $resultA);
+        $this->assertEquals($expectedA, $resultA);
+
+        $value    = 'Over the past 3 years, the semantic web activity has gained momentum with the widespread '.
+            'publishing of structured data as RDF. The Linked Data paradigm has therefore evolved from a practical '.
+            'research idea into a very promising candidate for addressing one of the biggest challenges in the area '.
+            'of intelligent information management: the exploitation of the Web as a platform for data and '.
+            'information integration in addition to document search. To translate this initial success into a '.
+            'world-scale disruptive reality, encompassing the Web 2.0 world and enterprise data alike, the following '.
+            'research challenges need to be addressed: improve coherence and quality of data published on the Web, '.
+            'close the performance gap between relational and RDF data management, establish trust on the Linked '.
+            'Data Web and generally lower the entrance barrier for data publishers and users. With partners among '.
+            'those who initiated and strongly supported the Linked Open Data initiative, the LOD2 project aims at '.
+            'tackling these challenges by developing:'.PHP_EOL.
+            '<ol>'.PHP_EOL.
+            '<li>enterprise-ready tools and methodologies for exposing and managing very large amounts of structured '.
+                'information on the Data Web,</li>'.PHP_EOL.
+            '<li>a testbed and bootstrap network of high-quality multi-domain, multi-lingual ontologies from sources '.
+                'such as Wikipedia and OpenStreetMap.</li>'.PHP_EOL.
+            '<li>algorithms based on machine learning for automatically interlinking and fusing data from '.
+                'the Web.</li>'.PHP_EOL.
+            '<li>standards and methods for reliably tracking provenance, ensuring privacy and data security as well '.
+                'as for assessing the quality of information.</li>'.PHP_EOL.
+            '<li>adaptive tools for searching, browsing, and authoring of Linked Data.</li>'.PHP_EOL.
+            '</ol>'.PHP_EOL.
+            'We will integrate and syndicate linked data with large-scale, existing applications and showcase the '.
+            'benefits in the three application scenarios of media & publishing, corporate data intranets and '.
+            'eGovernment. The resulting tools, methods and data sets have the potential to change the Web as we '.
+            'know it today.';
+
+        $statementsB = array(
+            'http://example.com/1' => array(
+                'http://example.com/2' => array(
+                    array('type' => 'literal', 'value' => $value)
+                )
+            )
+        );
+        $expectedB = '<http://example.com/1> <http://example.com/2> """Over the past 3 years, the semantic web '.
+            'activity has gained momentum with the widespread '.
+            'publishing of structured data as RDF. The Linked Data paradigm has therefore evolved from a practical '.
+            'research idea into a very promising candidate for addressing one of the biggest challenges in the area '.
+            'of intelligent information management: the exploitation of the Web as a platform for data and '.
+            'information integration in addition to document search. To translate this initial success into a '.
+            'world-scale disruptive reality, encompassing the Web 2.0 world and enterprise data alike, the following '.
+            'research challenges need to be addressed: improve coherence and quality of data published on the Web, '.
+            'close the performance gap between relational and RDF data management, establish trust on the Linked '.
+            'Data Web and generally lower the entrance barrier for data publishers and users. With partners among '.
+            'those who initiated and strongly supported the Linked Open Data initiative, the LOD2 project aims at '.
+            'tackling these challenges by developing:'.PHP_EOL.
+            '<ol>'.PHP_EOL.
+            '<li>enterprise-ready tools and methodologies for exposing and managing very large amounts of structured '.
+                'information on the Data Web,</li>'.PHP_EOL.
+            '<li>a testbed and bootstrap network of high-quality multi-domain, multi-lingual ontologies from sources '.
+                'such as Wikipedia and OpenStreetMap.</li>'.PHP_EOL.
+            '<li>algorithms based on machine learning for automatically interlinking and fusing data from '.
+                'the Web.</li>'.PHP_EOL.
+            '<li>standards and methods for reliably tracking provenance, ensuring privacy and data security as well '.
+                'as for assessing the quality of information.</li>'.PHP_EOL.
+            '<li>adaptive tools for searching, browsing, and authoring of Linked Data.</li>'.PHP_EOL.
+            '</ol>'.PHP_EOL.
+            'We will integrate and syndicate linked data with large-scale, existing applications and showcase the '.
+            'benefits in the three application scenarios of media & publishing, corporate data intranets and '.
+            'eGovernment. The resulting tools, methods and data sets have the potential to change the Web as we '.
+            'know it today.""" .'.PHP_EOL;
+
+        $resultB = $this->fixture->buildTripleString($statementsB);
+        $resultB = str_replace(PHP_EOL, "\n", $resultB);
+        $this->assertEquals($expectedB, $resultB);
+    }
+}

--- a/tests/unit/Erfurt/TestCase.php
+++ b/tests/unit/Erfurt/TestCase.php
@@ -77,6 +77,10 @@ class Erfurt_TestCase extends PHPUnit_Framework_TestCase
             if (isset($this->_testConfig->store->zenddb->dbname)) {
                 $dbName = $this->_testConfig->store->zenddb->dbname;
             }
+        } else if ($this->_testConfig->store->backend === 'stardog') {
+            if (isset($this->_testConfig->store->stardog->database)) {
+                $dbName = $this->_testConfig->store->stardog->database;
+            }
         }
 
         // make sure a test db was selected!
@@ -163,6 +167,16 @@ class Erfurt_TestCase extends PHPUnit_Framework_TestCase
         $this->markTestNeedsDatabase();
     }
 
+    public function markTestNeedsStardog()
+    {
+        $this->markTestNeedsTestConfig();
+        if ($this->_testConfig->store->backend !== 'stardog') {
+            $this->markTestSkipped('Skipped since other backend is under test.');
+        }
+
+        $this->markTestNeedsDatabase();
+    }
+
     private function _loadTestConfig(Zend_Config $config = null)
     {
         if (null === $this->_customTestConfig) {
@@ -196,7 +210,7 @@ class Erfurt_TestCase extends PHPUnit_Framework_TestCase
                 // this is useful, when we want to test with different stores without manually
                 // editing the config
                 $storeAdapter = getenv('EF_STORE_ADAPTER');
-                if (($storeAdapter === 'virtuoso') || ($storeAdapter === 'zenddb')) {
+                if (($storeAdapter === 'virtuoso') || ($storeAdapter === 'zenddb') || ($storeAdapter === 'stardog')) {
                     $this->_customTestConfig->store->backend = $storeAdapter;
                 } else if ($storeAdapter !== false) {
                     throw new Exception('Invalid value of $EF_STORE_ADAPTER: ' . $storeAdapter);


### PR DESCRIPTION
This implements Stardog as new backend adapter, originally inspired by @Matthimatiker in #86 

It uses [Guzzle 5.3](https://github.com/guzzle/guzzle/tree/5.3) as HTTP  client to request Stardog via [HTTP Interface](https://github.com/Complexible/stardog-docs/blob/master/src/doc/http.ad).

All operations as used for Virtuoso to query the store, add or remove statements should be supported. If versioning is enabled (default) an additional SQL ZendDB store is required.

The implemented integration test (`make test-integration-stardog`) completes with success.

Stardog can be installed as Docker Container from https://github.com/Dockerizing/Stardog

`config.ini` for Erfurt with Stardog should look like:
```
store.backend = stardog
versioning = true

; Stardog backend
store.stardog.base_url   = http://localhost:5820
store.stardog.username   = admin
store.stardog.password   = admin
store.stardog.database   = erfurt

; ZendDB
store.zenddb.dbname   = erfurt
store.zenddb.username = root
store.zenddb.password = password
store.zenddb.dbtype   = mysql
store.zenddb.host     = localhost
```