### PR TITLE
Add missing method to access control adapter

### DIFF
--- a/library/Erfurt/Ac/None.php
+++ b/library/Erfurt/Ac/None.php
@@ -73,4 +73,16 @@ class Erfurt_Ac_None
     {    
         // Nothing to do here...
     }
+
+    public function areModelsAllowed($type, $modelUris)
+    {
+        $results = array();
+        foreach ($modelUris as $modelUri) {
+            $modelUri = (string)$modelUri;
+
+            $results[$modelUri] = true;
+        }
+
+        return $results;
+    }
 }


### PR DESCRIPTION
The None AC adapter was missing a method that is called within the store.
This commit adds this missing method.