### PR TITLE
Add PHP 5.6, 7.0 and 7.1 to travis build and allow them to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ language: php
 
 php:
   - 5.4
+  - 5.6
+  - 7.0
+  - 7.1
+
+matrix:
+    allow_failures:
+        - php: 7.0
+        - php: 7.1
 
 sudo: false
 


### PR DESCRIPTION
This allows us to also test against later versions but not report as failed for not yet supported versions.
This way we can see, how far we are in supporting the later versions.