### PR TITLE
Error Codes for Various Exceptions

### DIFF
--- a/library/Erfurt/App.php
+++ b/library/Erfurt/App.php
@@ -896,7 +896,7 @@ class Erfurt_App
             try {
                 $this->_store->checkSetup();
             } catch (Erfurt_Store_Exception $e) {
-                if ($e->getCode() != 20) {
+                if ($e->getCode() != Erfurt_Exception::SYSTEM_MODELS_IMPORTED) {
                     throw $e;
                 }
             }

--- a/library/Erfurt/Exception.php
+++ b/library/Erfurt/Exception.php
@@ -11,10 +11,27 @@
  * @copyright   Copyright (c) 2012, {@link http://aksw.org AKSW}
  * @author      Stefan Berger <berger@intersolut.de>
  */
-class Erfurt_Exception extends Exception {
+class Erfurt_Exception extends Exception
+{
 
-    function display($pre = true) {
-        if ($pre) print '<pre>';  
+    /*
+     * All Erfurt Error Codes are saved in this file.
+     * The DEFAULT_ERROR should only be used to get
+     * access to the third Exception parameter
+     * The NON_FATAL_ERROR is not handled in Erfurt,
+     * but OntoWiki handles Exceptions with errorcodes
+     * greater than 0 (and smaller than equal 2000) differently
+     * The SYSTEM_MODELS_IMPORTED is thrown when 1 or more System
+     * Models are importet into the Store (it's a Store_Exception
+     * Code)
+     */
+    const DEFAULT_ERROR = 0;
+    const NON_FATAL_ERROR = 1;
+    const SYSTEM_MODELS_IMPORTED = 20;
+
+    function display($pre = true)
+    {
+        if ($pre) print '<pre>';
         echo "Erfurt_Exception: code $this->code ($this->message) " .
             "in line $this->line of $this->file\n";
         echo $this->getTraceAsString(), "\n";
@@ -22,4 +39,3 @@ class Erfurt_Exception extends Exception {
     }
 
 }
-?>

--- a/library/Erfurt/Sparql/Constraint.php
+++ b/library/Erfurt/Sparql/Constraint.php
@@ -295,7 +295,9 @@ class Erfurt_Sparql_Constraint
                 case '!':
                     if ($tree != array()) {
                         throw new Erfurt_Sparql_ParserException(
-                            'Unexpected "!" negation in constraint.', -1, current($this->_tokens)
+                            'Unexpected "!" negation in constraint.',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            current($this->_tokens)
                         );
                     }
                     $tree['negated'] = true;
@@ -322,7 +324,7 @@ class Erfurt_Sparql_Constraint
                     // Variables need parenthesizes first
                     throw new Erfurt_Sparql_ParserException(
                         'FILTER expressions that start with a variable need parenthesizes.',
-                        -1,
+                        Erfurt_Exception::DEFAULT_ERROR,
                         current($this->_tokens)
                     );
                 }
@@ -335,7 +337,9 @@ class Erfurt_Sparql_Constraint
             } else if (substr($tok, 0, 2) === '_:') {
                 // syntactic blank nodes not allowed in filter
                 throw new Erfurt_Sparql_ParserException(
-                    'Syntactic Blanknodes not allowed in FILTER.', -1, current($this->_tokens)
+                    'Syntactic Blanknodes not allowed in FILTER.',
+                    Erfurt_Exception::DEFAULT_ERROR,
+                    current($this->_tokens)
                 );
             } else if (substr($tok, 0, 2) === '^^') {
                 $part[count($part) - 1]['datatype'] = $this->_query->getFullUri(substr($tok, 2));
@@ -386,7 +390,11 @@ class Erfurt_Sparql_Constraint
         }
 
         if ((count($tree) === 0) && (count($part) > 1)) {
-            throw new Erfurt_Sparql_ParserException('Failed to parse constraint.', -1, current($this->_tokens));
+            throw new Erfurt_Sparql_ParserException(
+                'Failed to parse constraint.',
+                Erfurt_Exception::DEFAULT_ERROR,
+                current($this->_tokens)
+            );
         }
 
         if (!isset($tree['type']) && isset($part[0])) {

--- a/library/Erfurt/Sparql/Parser.php
+++ b/library/Erfurt/Sparql/Parser.php
@@ -517,7 +517,11 @@ class Erfurt_Sparql_Parser
         if ($this->_iriCheck(current($this->_tokens))) {
             $this->_query->setBase(current($this->_tokens));
         } else {
-            throw new Erfurt_Sparql_ParserException('IRI expected', -1, key($this->_tokens));
+            throw new Erfurt_Sparql_ParserException(
+                'IRI expected',
+                Erfurt_Exception::DEFAULT_ERROR,
+                key($this->_tokens)
+            );
         }
     }
     
@@ -589,7 +593,10 @@ class Erfurt_Sparql_Parser
             if (next($this->_tokens) === '}') {
                 // list may not occure standalone in a pattern.
                 throw new Erfurt_Sparql_ParserException(
-                    'A list may not occur standalone in a pattern.', -1, key($this->_tokens));
+                    'A list may not occur standalone in a pattern.',
+                    Erfurt_Exception::DEFAULT_ERROR,
+                    key($this->_tokens)
+                );
             }
             prev($this->_tokens);
         }
@@ -766,7 +773,10 @@ class Erfurt_Sparql_Parser
                 case '!':
                     if ($tree != array()) {
                         throw new Erfurt_Sparql_ParserException(
-                            'Unexpected "!" negation in constraint.', -1, current($this->_tokens));
+                            'Unexpected "!" negation in constraint.',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            current($this->_tokens)
+                        );
                     }
                     $tree['negated'] = true;
                     continue 2;
@@ -790,7 +800,11 @@ class Erfurt_Sparql_Parser
             if ($this->_varCheck($tok)) {
                 if (!$parens && $nLevel === 0) {
                     // Variables need parenthesizes first
-                    throw new Erfurt_Sparql_ParserException('FILTER expressions that start with a variable need parenthesizes.', -1, current($this->_tokens));
+                    throw new Erfurt_Sparql_ParserException(
+                        'FILTER expressions that start with a variable need parenthesizes.',
+                        Erfurt_Exception::DEFAULT_ERROR,
+                        current($this->_tokens)
+                    );
                 }
                 
                 $part[] = array(
@@ -800,8 +814,11 @@ class Erfurt_Sparql_Parser
                 );
             } else if (substr($tok, 0, 2) === '_:') {
                 // syntactic blank nodes not allowed in filter
-                throw new Erfurt_Sparql_ParserException('Syntactic Blanknodes not allowed in FILTER.', -1,
-                                current($this->_tokens));
+                throw new Erfurt_Sparql_ParserException(
+                    'Syntactic Blanknodes not allowed in FILTER.',
+                    Erfurt_Exception::DEFAULT_ERROR,
+                    current($this->_tokens)
+                );
             } else if (substr($tok, 0, 2) === '^^') {
                 $part[count($part) - 1]['datatype'] = $this->_query->getFullUri(substr($tok, 2));
             } else if ($tok[0] === '@') {
@@ -850,7 +867,11 @@ class Erfurt_Sparql_Parser
         }
 
         if ((count($tree) === 0) && (count($part) > 1)) {
-            throw new Erfurt_Sparql_ParserException('Failed to parse constraint.', -1, current($this->_tokens));
+            throw new Erfurt_Sparql_ParserException(
+                'Failed to parse constraint.',
+                Erfurt_Exception::DEFAULT_ERROR,
+                current($this->_tokens)
+            );
         }
         
         if (!isset($tree['type']) && isset($part[0])) {
@@ -876,8 +897,11 @@ class Erfurt_Sparql_Parser
         if (current($this->_tokens) === '{') {
             $this->_parseGraphPattern(false, false, false, true);
         } else {
-            throw new Erfurt_Sparql_ParserException('Unable to parse CONSTRUCT part. "{" expected.', -1, 
-                            key($this->_tokens));
+            throw new Erfurt_Sparql_ParserException(
+                'Unable to parse CONSTRUCT part. "{" expected.',
+                Erfurt_Exception::DEFAULT_ERROR,
+                key($this->_tokens)
+            );
         }
 
         while (true) {
@@ -928,8 +952,11 @@ class Erfurt_Sparql_Parser
             } else if ($this->_varCheck(current($this->_tokens))) {
                 $this->_query->addFrom(current($this->_tokens));
             } else {
-                throw new Erfurt_Sparql_ParserException('Variable, iri or qname expected in FROM', -1,
-                                key($this->_tokens));
+                throw new Erfurt_Sparql_ParserException(
+                    'Variable, iri or qname expected in FROM',
+                    Erfurt_Exception::DEFAULT_ERROR,
+                    key($this->_tokens)
+                );
             }
         } else {
             $this->_fastForward();
@@ -938,8 +965,11 @@ class Erfurt_Sparql_Parser
             } else if ($this->_varCheck(current($this->_tokens))) {
                 $this->_query->addFromNamed(current($this->_tokens));
             } else {
-                throw new Erfurt_Sparql_ParserException('Variable, Iri or qname expected in FROM NAMED', -1, 
-                                key($this->_tokens));
+                throw new Erfurt_Sparql_ParserException(
+                    'Variable, Iri or qname expected in FROM NAMED',
+                    Erfurt_Exception::DEFAULT_ERROR,
+                    key($this->_tokens)
+                );
             }
         }
     }
@@ -957,7 +987,11 @@ class Erfurt_Sparql_Parser
         if (!$this->_varCheck($name) && !$this->_iriCheck($name) && !$this->_qnameCheck($name)) {
             $msg = $name;
             $msg = preg_replace('/</', '&lt;', $msg);
-            throw new Erfurt_Sparql_ParserException('IRI or Var expected.', -1, key($this->_tokens));
+            throw new Erfurt_Sparql_ParserException(
+                'IRI or Var expected.',
+                Erfurt_Exception::DEFAULT_ERROR,
+                key($this->_tokens)
+            );
         }
         $this->_fastForward();
 
@@ -989,7 +1023,10 @@ class Erfurt_Sparql_Parser
 
         if (current($this->_tokens) !== '{') {
             throw new Erfurt_Sparql_ParserException(
-                'A graph pattern needs to start with "{".', -1, key($this->_tokens));
+                'A graph pattern needs to start with "{".',
+                Erfurt_Exception::DEFAULT_ERROR,
+                key($this->_tokens)
+            );
         }
         
         // A new graph pattern invalidates the use of all previous blank nodes.
@@ -1043,8 +1080,11 @@ class Erfurt_Sparql_Parser
                     // Check whether the previous token is {, for this is not allowed.
                     $this->_rewind();
                     if (current($this->_tokens) === '{') {
-                        throw new Erfurt_Sparql_ParserException('A dot/semicolon must not follow a "{" directly.', -1,
-                                        key($this->_tokens));
+                        throw new Erfurt_Sparql_ParserException(
+                            'A dot/semicolon must not follow a "{" directly.',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            key($this->_tokens)
+                        );
                     }
                     $this->_fastForward();
                     
@@ -1111,7 +1151,11 @@ class Erfurt_Sparql_Parser
                         $this->_fastForward();
                         $this->_parseOrderCondition();
                     } else {
-                        throw new Erfurt_Sparql_ParserException('"BY" expected.', -1, key($this->_tokens));
+                        throw new Erfurt_Sparql_ParserException(
+                            '"BY" expected.',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            key($this->_tokens)
+                        );
                     }
                     break;
                 case 'limit':
@@ -1159,8 +1203,11 @@ class Erfurt_Sparql_Parser
             $node = '?' . $node;
             
             if (isset($this->_usedBlankNodes[$node]) && $this->_usedBlankNodes[$node] === false) {
-                throw new Erfurt_Sparql_ParserException('Reuse of blank node id not allowed here.' -1,
-                            key($this->_tokens));
+                throw new Erfurt_Sparql_ParserException(
+                    'Reuse of blank node id not allowed here.',
+                    Erfurt_Exception::DEFAULT_ERROR,
+                    key($this->_tokens)
+                );
             }
 
             $this->_query->addUsedVar($node);
@@ -1218,13 +1265,17 @@ class Erfurt_Sparql_Parser
                 }
             }
             if (substr($node, -1) != '>') {
-                throw new Erfurt_Sparql_ParserException('Unclosed IRI: ' . $node, -1, key($this->_tokens));
+                throw new Erfurt_Sparql_ParserException(
+                    'Unclosed IRI: ' . $node,
+                    Erfurt_Exception::DEFAULT_ERROR,
+                    key($this->_tokens)
+                );
             }
             return $this->_parseNode($node);
         } else {
             throw new Erfurt_Sparql_ParserException(
                 '"' . $node . '" is neither a valid rdf- node nor a variable.',
-                -1,
+                Erfurt_Exception::DEFAULT_ERROR,
                 key($this->_tokens)
             );
         }
@@ -1264,15 +1315,21 @@ class Erfurt_Sparql_Parser
                     
                         $val['val'] = $fName;
                     } else {
-                        throw new Erfurt_Sparql_ParserException('Variable expected in ORDER BY clause.', -1, 
-                                        key($this->_tokens));
+                        throw new Erfurt_Sparql_ParserException(
+                            'Variable expected in ORDER BY clause.',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            key($this->_tokens)
+                        );
                     }
                     
                     $this->_fastForward();
                     
                     if (current($this->_tokens) != ')') {
-                        throw new Erfurt_Sparql_ParserException('missing ")" in ORDER BY clause.', -1,
-                                        key($this->_tokens));
+                        throw new Erfurt_Sparql_ParserException(
+                            'missing ")" in ORDER BY clause.',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            key($this->_tokens)
+                        );
                     }
                 
                     $val['type'] = 'desc';
@@ -1296,15 +1353,21 @@ class Erfurt_Sparql_Parser
 
                         $val['val'] = $fName;
                     } else {
-                        throw new Erfurt_Sparql_ParserException('Variable expected in ORDER BY clause. ', -1, 
-                                        key($this->_tokens));
+                        throw new Erfurt_Sparql_ParserException(
+                            'Variable expected in ORDER BY clause. ',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            key($this->_tokens)
+                        );
                     }
                 
                     $this->_fastForward();
                 
                     if (current($this->_tokens) !== ')') {
-                        throw new Erfurt_Sparql_ParserException('missing ")" in ORDER BY clause.', -1,          
-                                        key($this->_tokens));
+                        throw new Erfurt_Sparql_ParserException(
+                            'missing ")" in ORDER BY clause.',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            key($this->_tokens)
+                        );
                     }
                 
                     $val['type'] = 'asc';
@@ -1359,7 +1422,11 @@ class Erfurt_Sparql_Parser
             $uri = substr(current($this->_tokens), 1, -1);
             $this->_query->addPrefix($prefix, $uri);
         } else {
-            throw new Erfurt_Sparql_ParserException('IRI expected', -1, key($this->_tokens));
+            throw new Erfurt_Sparql_ParserException(
+                'IRI expected',
+                Erfurt_Exception::DEFAULT_ERROR,
+                key($this->_tokens)
+            );
         }
     }
 
@@ -1454,8 +1521,11 @@ class Erfurt_Sparql_Parser
                 $currentFunc = null;
             } else if ($curLow == 'as') {
                 if ($currentVar === null) {
-                    throw new Erfurt_Sparql_ParserException('AS requires a variable left and right', -1,
-                                    key($this->_tokens));
+                    throw new Erfurt_Sparql_ParserException(
+                        'AS requires a variable left and right',
+                        Erfurt_Exception::DEFAULT_ERROR,
+                        key($this->_tokens)
+                    );
                 }
                 $bWaitForRenaming = true;
             } else if (in_array($curLow, self::$_sops)) {
@@ -1464,7 +1534,10 @@ class Erfurt_Sparql_Parser
 
             if (!current($this->_tokens)) {
                 throw new Erfurt_Sparql_ParserException(
-                    'Unexpected end of query.', -1, key($this->_tokens));
+                    'Unexpected end of query.',
+                    Erfurt_Exception::DEFAULT_ERROR,
+                    key($this->_tokens)
+                );
             }
         }
 
@@ -1474,7 +1547,11 @@ class Erfurt_Sparql_Parser
         prev($this->_tokens);
 
         if (count($this->_query->getResultVars()) == 0) {
-            throw new Erfurt_Sparql_ParserException('Variable or "*" expected.', -1, key($this->_tokens));
+            throw new Erfurt_Sparql_ParserException(
+                'Variable or "*" expected.',
+                Erfurt_Exception::DEFAULT_ERROR,
+                key($this->_tokens)
+            );
         }
     }
     
@@ -1527,8 +1604,11 @@ class Erfurt_Sparql_Parser
                     // Check whether the previous token is a dot too, for this is not allowed.
                     $this->_rewind();
                     if (current($this->_tokens) === '.') {
-                        throw new Erfurt_Sparql_ParserException('A semicolon must not follow a dot directly.', -1,
-                                        key($this->_tokens));
+                        throw new Erfurt_Sparql_ParserException(
+                            'A semicolon must not follow a dot directly.',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            key($this->_tokens)
+                        );
                     }
                     $this->_fastForward();
                 
@@ -1538,14 +1618,21 @@ class Erfurt_Sparql_Parser
                     break;
                 case '.':
                     if ($dotAllowed === false) {
-                        throw new Erfurt_Sparql_ParserException('A dot is not allowed here.', -1, key($this->_tokens));
+                        throw new Erfurt_Sparql_ParserException(
+                            'A dot is not allowed here.',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            key($this->_tokens)
+                        );
                     }
                 
                     // Check whether the previous token is a dot too, for this is not allowed.
                     $this->_rewind();
                     if (current($this->_tokens) === '.') {
-                        throw new Erfurt_Sparql_ParserException('A dot may not follow a dot directly.', -1,
-                                        key($this->_tokens));
+                        throw new Erfurt_Sparql_ParserException(
+                            'A dot may not follow a dot directly.',
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            key($this->_tokens)
+                        );
                     }
                     $this->_fastForward();
                     
@@ -1557,8 +1644,11 @@ class Erfurt_Sparql_Parser
                     $this->_parseGraph();
                     break;
                 case ',':
-                    throw new Erfurt_Sparql_ParserException('A comma is not allowed directly after a triple.', -1,
-                                    key($this->_tokens));
+                    throw new Erfurt_Sparql_ParserException(
+                        'A comma is not allowed directly after a triple.',
+                        Erfurt_Exception::DEFAULT_ERROR,
+                        key($this->_tokens)
+                    );
                 
                     $prev     = true;
                     $prevPred = true;
@@ -1598,8 +1688,12 @@ class Erfurt_Sparql_Parser
                     break;
                 default:
                     if ($needsDot === true) {
-                        throw new Erfurt_Sparql_ParserException('Two triple pattern need to be seperated by a dot. In Query: '.htmlentities($this->_query), -1,
-                                        key($this->_tokens));
+                        throw new Erfurt_Sparql_ParserException(
+                            'Two triple pattern need to be seperated by a dot. In Query: '
+                            .htmlentities($this->_query),
+                            Erfurt_Exception::DEFAULT_ERROR,
+                            key($this->_tokens)
+                        );
                     }
                 
                     $dotAllowed = false;
@@ -1616,8 +1710,11 @@ class Erfurt_Sparql_Parser
                     } else {
                         // Predicates may not be blank nodes.
                         if ((current($this->_tokens) === '[') || (substr(current($this->_tokens), 0, 2) === '_:')) {
-                            throw new Erfurt_Sparql_ParserException('Predicates may not be blank nodes.', -1,
-                                            key($this->_tokens));
+                            throw new Erfurt_Sparql_ParserException(
+                                'Predicates may not be blank nodes.',
+                                Erfurt_Exception::DEFAULT_ERROR,
+                                key($this->_tokens)
+                            );
                         }
 
                         $pre = $this->_parseNode();
@@ -1665,8 +1762,11 @@ class Erfurt_Sparql_Parser
         if (current($this->_tokens) === '{') {
             $this->_parseGraphPattern();
         } else {
-            throw new Erfurt_Sparql_ParserException('Unable to parse WHERE part. "{" expected in Query. ', -1,
-                            key($this->_tokens));
+            throw new Erfurt_Sparql_ParserException(
+                'Unable to parse WHERE part. "{" expected in Query. ',
+                Erfurt_Exception::DEFAULT_ERROR,
+                key($this->_tokens)
+            );
         }
     }
 
@@ -1702,7 +1802,11 @@ class Erfurt_Sparql_Parser
                 return true;
             }
             
-            throw new Erfurt_Sparql_ParserException('Unbound Prefix: <i>' . $hits{1} . '</i>', -1, key($this->_tokens));
+            throw new Erfurt_Sparql_ParserException(
+                'Unbound Prefix: <i>' . $hits{1} . '</i>',
+                Erfurt_Exception::DEFAULT_ERROR,
+                key($this->_tokens)
+            );
         } else {
             return false;
         }

--- a/library/Erfurt/Sparql/Query2/Filter.php
+++ b/library/Erfurt/Sparql/Query2/Filter.php
@@ -26,7 +26,11 @@ class Erfurt_Sparql_Query2_Filter extends Erfurt_Sparql_Query2_ElementHelper
      */
     public function __construct($element) {
         if(!($element instanceof Erfurt_Sparql_Query2_Constraint || is_bool($element))){
-            throw new Exception('Argument 1 passed to Erfurt_Sparql_Query2_Filter::__construct must be Instance of Erfurt_Sparql_Query2_Constraint', 1);
+            throw new Exception(
+                'Argument 1 passed to Erfurt_Sparql_Query2_Filter::__construct must be'
+                .'Instance of Erfurt_Sparql_Query2_Constraint',
+                Erfurt_Exception::NON_FATAL_ERROR
+            );
         }
         if(is_bool($element)){
             $element = new Erfurt_Sparql_Query2_BooleanLiteral($element);
@@ -50,7 +54,11 @@ class Erfurt_Sparql_Query2_Filter extends Erfurt_Sparql_Query2_ElementHelper
      */
     public function setConstraint($element) {
        if(!($element instanceof Erfurt_Sparql_Query2_Constraint || is_bool($element))){
-            throw new Exception('Argument 1 passed to Erfurt_Sparql_Query2_Filter::__construct must be Instance of Erfurt_Sparql_Query2_Constraint', 1);
+            throw new Exception(
+                'Argument 1 passed to Erfurt_Sparql_Query2_Filter::__construct must be'
+                .' Instance of Erfurt_Sparql_Query2_Constraint',
+                Erfurt_Exception::NON_FATAL_ERROR
+            );
        }
        if(is_bool($element)){
             $element = new Erfurt_Sparql_Query2_BooleanLiteral($element);

--- a/library/Erfurt/Store.php
+++ b/library/Erfurt/Store.php
@@ -525,7 +525,7 @@ class Erfurt_Store
         if ($returnValue === false) {
             throw new Erfurt_Store_Exception(
                 'One or more system models imported.',
-                20
+                Erfurt_Exception::SYSTEM_MODELS_IMPORTED
             );
         }
 
@@ -1045,7 +1045,7 @@ EOF;
                 try {
                     $this->checkSetup();
                 } catch (Erfurt_Store_Exception $e) {
-                    if ($e->getCode() === 20) {
+                    if ($e->getCode() === Erfurt_Exception::SYSTEM_MODELS_IMPORTED) {
                         // Everything is fine, system models now imported
                     } else {
                         throw $e;

--- a/library/Erfurt/Store/Adapter/EfZendDb.php
+++ b/library/Erfurt/Store/Adapter/EfZendDb.php
@@ -53,9 +53,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
 
         $this->_connect();
 
-        // we want indexed results
-        //$this->_dbConn->setFetchMode(Zend_Db::FETCH_NUM);
-
         // load title properties for model titles
         $config = Erfurt_App::getInstance()->getConfig();
         if (isset($config->properties->title)) {
@@ -63,7 +60,8 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
         }
     }
 
-    protected function _connect(){
+    protected function _connect()
+    {
         switch (strtolower($this->_adapterOptions['dbtype'])) {
             case 'mysql':
                 if (extension_loaded('mysqli')) {
@@ -99,37 +97,22 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             // maybe a needed php extension is not loaded?!
             throw new Erfurt_Exception('An error with the specified database adapter occured.', -1);
         }
-
-        // we want indexed results
-        //$this->_dbConn->setFetchMode(Zend_Db::FETCH_NUM);
     }
 
     /**
      * save all but except the db connection
      * @return array keys to save
      */
-    function __sleep(){
+    function __sleep()
+    {
         $vars = get_object_vars($this);
         unset($vars['_dbConn']);
         return array_keys($vars);
     }
 
-    function __wakeUp(){
-        $this->_connect();
-    }
-
-    public function __destruct()
+    function __wakeUp()
     {
-        #$log = Erfurt_App::getInstance()->getLog();
-
-        #$profiles = $this->_dbConn->getProfiler()->getQueryProfiles();
-
-        #foreach ($profiles as $profile) {
-        #    $debugStr = 'Query: ' . $profile->getQuery() . PHP_EOL;
-        #    $debugStr .= 'Time: ' . $profile->getElapsedSecs() . PHP_EOL;
-        #
-        #    $log->debug($debugStr);
-        #}
+        $this->_connect();
     }
 
     // ------------------------------------------------------------------------
@@ -237,15 +220,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
 
                     $sqlString .= "($graphId, $sValue, $pValue, $oValue,";
 
-                    #$data = array(
-                    #    'g'     => $graphId,
-                    #    's'     => $subject,
-                    #    'p'     => $predicate,
-                    #    'o'     => $object['value'],
-                    #    'st'    => $subjectIs,
-                    #    'ot'    => $objectIs
-                    #);
-
                     if ($sRef !== false) {
                         $sqlString .= "$sRef,";
                     } else {
@@ -264,9 +238,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
 
                     $sqlString .= "$subjectIs,$objectIs,'$lang',";
 
-                    #$data['ol'] = $lang;
-
-
                     if (strlen((string)$dType) > $this->_getSchemaRefThreshold()) {
                         $dTypeHash = md5((string)$dType);
 
@@ -282,25 +253,11 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
 
                         $sqlString .= "'$dType',$dtRef)";
                     } else {
-                        #$data['od'] = $dType;
                         $sqlString .= "'$dType',\N)";
                     }
 
                     $insertArray[] = $sqlString;
                     $counter++;
-
-                    #try {
-                    #    $this->_dbConn->insert('ef_stmt', $data);
-                    #    $counter++;
-                    #} catch (Exception $e) {
-                    #    if ($this->_getNormalizedErrorCode() === 1000) {
-                    #        continue;
-                    #    } else {
-                    #        $this->_dbConn->rollback();
-                    #        throw new Erfurt_Store_Adapter_Exception('Bulk insertion of statements failed: ' .
-                    #                        $this->_dbConn->getConnection()->error);
-                    #    }
-                    #}
                 }
             }
         }
@@ -360,7 +317,7 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             $query->setSelectClause("COUNT DISTINCT $countSpec");
         } else {
             // i made a (uncool) hack to fix this, the "-" is there because i didnt want to change tokenization
-            $query->setSelectClause("COUNT-DISTINCT $countSpec"); 
+            $query->setSelectClause("COUNT-DISTINCT $countSpec");
         }
         $query->setFrom($graphIris)
               ->setWherePart($whereSpec);
@@ -473,7 +430,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
         if ($predicate !== null) {
             $whereString .= " AND p = '$predicate'";
         }
-
 
         if (null !== $subject) {
             if (substr($subject, 0, 2) === '_:') {
@@ -807,7 +763,7 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
     /** @see Erfurt_Store_Adapter_Interface */
     public function importRdf($modelUri, $data, $type, $locator)
     {
-// TODO fix or remove
+        // TODO fix or remove
         if ($this->_dbConn instanceof Zend_Db_Adapter_Mysqli) {
             $parser = Erfurt_Syntax_RdfParser::rdfParserWithFormat($type);
             $parsedArray = $parser->parse($data, $locator, $modelUri, false);
@@ -996,8 +952,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
                 } else {
                     $sql .= "\N,\N)";
                 }
-
-                //$this->_dbConn->getConnection()->query($sql);
             }
 
             if ($count > 10000) {
@@ -1042,16 +996,15 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
     /** @see Erfurt_Store_Adapter_Interface */
     public function sparqlAsk($query)
     {
-	//TODO works for me...., why hasnt this be enabled earlier? is the same as sparqlQuery...
-        //looks like the engine supports it. but there is probably a reason for this not to be supported
-		$start = microtime(true);
+        $start = microtime(true);
 
         $engine = new Erfurt_Sparql_EngineDb_Adapter_EfZendDb($this->_dbConn, $this->_getModelInfos());
 
         $parser = new Erfurt_Sparql_Parser();
 
-        if(!($query instanceof Erfurt_Sparql_Query))
-        	$query = $parser->parse((string)$query);
+        if (!($query instanceof Erfurt_Sparql_Query)) {
+            $query = $parser->parse((string)$query);
+        }
 
         $result = $engine->queryModel($query);
 
@@ -1067,7 +1020,11 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
     /** @see Erfurt_Store_Adapter_Interface */
     public function sparqlQuery($query, $options=array())
     {
-        $resultform =(isset($options[Erfurt_Store::RESULTFORMAT]))?$options[Erfurt_Store::RESULTFORMAT]:Erfurt_Store::RESULTFORMAT_PLAIN;
+        $resultform = Erfurt_Store::RESULTFORMAT_PLAIN;
+
+        if (isset($options[Erfurt_Store::RESULTFORMAT])) {
+            $resultform = $options[Erfurt_Store::RESULTFORMAT];
+        }
 
         $start = microtime(true);
 
@@ -1115,8 +1072,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
                 $result = $this->_dbConn->getConnection()->query($sqlQuery);
             }
 
-
-
             if ( $result !== true ) {
                 throw new Erfurt_Store_Adapter_Exception(
                     'SQL query failed: ' .
@@ -1155,22 +1110,22 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
         $createTable = 'CREATE TABLE `' . (string) $tableName . '` (';
 
         $i = 0;
-	    foreach ( $columns as $columnName => $columnSpec ) {
-	        $createTable .= PHP_EOL
-	                     .  '`' . $columnName . '` '
-	                     .  $columnSpec . (($i < count($columns)-1) ? ',' : '');
-	        ++$i;
-	    }
-	    $createTable .= PHP_EOL
-	                 .  ')';
-	    $success = $this->_dbConn->getConnection()->query($createTable);
+        foreach ( $columns as $columnName => $columnSpec ) {
+            $createTable .= PHP_EOL
+                         .  '`' . $columnName . '` '
+                         .  $columnSpec . (($i < count($columns)-1) ? ',' : '');
+            ++$i;
+        }
+        $createTable .= PHP_EOL
+                     .  ')';
+        $success = $this->_dbConn->getConnection()->query($createTable);
 
-	    if ( !$success ) {
-// TODO dedicated exception
-	        throw new Exception('Could not create database table with name ' . $tableName . '.');
-	    } else {
-	        return $success;
-	    }
+        if ( !$success ) {
+            // TODO dedicated exception
+            throw new Exception('Could not create database table with name ' . $tableName . '.');
+        } else {
+            return $success;
+        }
     }
 
     /**
@@ -1206,7 +1161,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             );
         }
 
-
         // Insert id of the current schema into the ef_info table.
         $sql = 'INSERT INTO ef_info (schema_id) VALUES ("1.0")';
 
@@ -1220,15 +1174,14 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             );
         }
 
-
         // Create ef_graph table.
         $sql = 'CREATE TABLE IF NOT EXISTS ef_graph (
-        	        id			INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-        	        uri			VARCHAR(160) COLLATE ascii_bin NOT NULL,
-        	        uri_r	    INT UNSIGNED DEFAULT NULL,
-        	        base		VARCHAR(160) COLLATE ascii_bin DEFAULT NULL,
-        	        base_r	    INT UNSIGNED DEFAULT NULL,
-        	        UNIQUE unique_graph (uri)
+                    id          INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+                    uri         VARCHAR(160) COLLATE ascii_bin NOT NULL,
+                    uri_r       INT UNSIGNED DEFAULT NULL,
+                    base        VARCHAR(160) COLLATE ascii_bin DEFAULT NULL,
+                    base_r      INT UNSIGNED DEFAULT NULL,
+                    UNIQUE unique_graph (uri)
                 ) ENGINE = MyISAM DEFAULT CHARSET = ascii;';
 
         $success = false;
@@ -1245,24 +1198,24 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
 
         // Create ef_stmt table.
         $sql = 'CREATE TABLE IF NOT EXISTS ef_stmt (
-            	    id 		INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-            	    g	    INT UNSIGNED NOT NULL,                      # foreign key to ef_graph
-            	    s		VARCHAR(160) COLLATE ascii_bin NOT NULL,    # subject or subject hash
-            	    p		VARCHAR(160) COLLATE ascii_bin NOT NULL,    # predicate or predicate hash
-            	    o		VARCHAR(160) COLLATE utf8_bin NOT NULL,     # object or object hash
-            	    s_r     INT UNSIGNED DEFAULT NULL,                  # foreign key to ef_uri
-            	    p_r     INT UNSIGNED DEFAULT NULL,                  # foreign key to ef_uri
-            	    o_r     INT UNSIGNED DEFAULT NULL,                  # foreign key to ef_uri or ef_lit
-            	    st 		TINYINT(1) UNSIGNED NOT NULL,				# 0 - uri, 1 - bnode
-            	    ot 		TINYINT(1) UNSIGNED NOT NULL,				# 0 - uri, 1 - bnode, 2 - literal
-            	    ol 		VARCHAR(10) COLLATE ascii_bin NOT NULL,
-            	    od 	    VARCHAR(160) COLLATE ascii_bin NOT NULL,
-            	    od_r 	INT UNSIGNED DEFAULT NULL,
-            	    UNIQUE  unique_stmt (g, s, p, o, st, ot, ol, od),
-            	    INDEX   idx_g_p_o_ot (g, p, o, ot),
-            	    INDEX   idx_g_o_ot (g, o, ot)
-            	    #INDEX   idx_o_g_p_ot (o, g, p, ot)
-            	    #INDEX   idx_s_g_p_st (s, g, p, st)
+                    id      INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+                    g       INT UNSIGNED NOT NULL,                      # foreign key to ef_graph
+                    s       VARCHAR(160) COLLATE ascii_bin NOT NULL,    # subject or subject hash
+                    p       VARCHAR(160) COLLATE ascii_bin NOT NULL,    # predicate or predicate hash
+                    o       VARCHAR(160) COLLATE utf8_bin NOT NULL,     # object or object hash
+                    s_r     INT UNSIGNED DEFAULT NULL,                  # foreign key to ef_uri
+                    p_r     INT UNSIGNED DEFAULT NULL,                  # foreign key to ef_uri
+                    o_r     INT UNSIGNED DEFAULT NULL,                  # foreign key to ef_uri or ef_lit
+                    st      TINYINT(1) UNSIGNED NOT NULL,               # 0 - uri, 1 - bnode
+                    ot      TINYINT(1) UNSIGNED NOT NULL,               # 0 - uri, 1 - bnode, 2 - literal
+                    ol      VARCHAR(10) COLLATE ascii_bin NOT NULL,
+                    od         VARCHAR(160) COLLATE ascii_bin NOT NULL,
+                    od_r     INT UNSIGNED DEFAULT NULL,
+                    UNIQUE  unique_stmt (g, s, p, o, st, ot, ol, od),
+                    INDEX   idx_g_p_o_ot (g, p, o, ot),
+                    INDEX   idx_g_o_ot (g, o, ot)
+                    #INDEX   idx_o_g_p_ot (o, g, p, ot)
+                    #INDEX   idx_s_g_p_st (s, g, p, st)
                 ) ENGINE = MyISAM DEFAULT CHARSET = ascii;';
 
         $success = false;
@@ -1275,33 +1228,13 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             );
         }
 
-        /*
-        // Create ef_ns table.
-        $sql = 'CREATE TABLE IF NOT EXISTS ef_ns (
-        	        id		INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-        	        g	    INT UNSIGNED NOT NULL,
-        	        ns		VARCHAR(160) COLLATE ascii_bin NOT NULL,
-        	        ns_r	INT UNSIGNED DEFAULT NULL,
-        	        prefix	VARCHAR(160) COLLATE ascii_bin NOT NULL,
-        	        UNIQUE unique_ns (g, ns, prefix)
-                ) ENGINE = MyISAM DEFAULT CHARSET = ascii;';
-
-        $success = false;
-        $success = $this->_dbConn->getConnection()->query($sql);
-
-        if (!$success) {
-             throw new Erfurt_Store_Adapter_Exception('Creation of table "ef_ns" failed: ' .
-                            $this->_dbConn->getConnection()->error);
-        }
-        */
-
         // Create ef_uri table.
         $sql = 'CREATE TABLE IF NOT EXISTS ef_uri (
-        	        id	INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-        	        g	INT UNSIGNED NOT NULL,
-        	        v	LONGTEXT COLLATE ascii_bin NOT NULL,
-        	        vh  CHAR(32) COLLATE ascii_bin NOT NULL,
-        	        UNIQUE unique_uri (g, vh)
+                    id  INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+                    g   INT UNSIGNED NOT NULL,
+                    v   LONGTEXT COLLATE ascii_bin NOT NULL,
+                    vh  CHAR(32) COLLATE ascii_bin NOT NULL,
+                    UNIQUE unique_uri (g, vh)
                 ) ENGINE = MyISAM DEFAULT CHARSET = ascii;';
 
         $success = false;
@@ -1314,14 +1247,13 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             );
         }
 
-
         // Create ef_lit table.
         $sql = 'CREATE TABLE IF NOT EXISTS ef_lit (
-        	        id	INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
-        	        g	INT UNSIGNED NOT NULL,
-        	        v	LONGTEXT COLLATE utf8_bin NOT NULL,
-        	        vh  CHAR(32) COLLATE ascii_bin NOT NULL,
-        	        UNIQUE unique_lit (g, vh)
+                    id  INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+                    g   INT UNSIGNED NOT NULL,
+                    v   LONGTEXT COLLATE utf8_bin NOT NULL,
+                    vh  CHAR(32) COLLATE ascii_bin NOT NULL,
+                    UNIQUE unique_lit (g, vh)
                 ) ENGINE = MyISAM DEFAULT CHARSET = ascii;';
 
         $success = false;
@@ -1340,7 +1272,7 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
      */
     private function _createTablesSqlsrv()
     {
-                //#####################################################################
+        //#####################################################################
         // Create table ef_info if not existing
 
         $sqlsrv ='IF NOT EXISTS
@@ -1359,7 +1291,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             );
         }
 
-
         // Insert id of the current schema into the ef_info table.
         $sql = 'INSERT INTO ef_info (schema_id) VALUES (1.0)';
 
@@ -1372,8 +1303,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
                 $this->_dbConn->getConnection()->error
             );
         }
-
-
 
         //#####################################################################
         // Create table ef_graph if not existing
@@ -1435,7 +1364,7 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             );
         }
 
-//#####################################################################
+        //#####################################################################
         // Create table ef_uri if not existing
 
         $sqlsrv ='IF NOT EXISTS
@@ -1513,7 +1442,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
                             );
                         }
                     }
-
                 } else {
                     throw new Erfurt_Store_Adapter_Exception(
                         'Store: Error while fetching model and namespace infos.',
@@ -1591,8 +1519,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
         }
     }
 
-
-
     protected function _insertValueInto($tableName, $graphId, $value, $valueHash)
     {
         $data = array(
@@ -1657,14 +1583,11 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             throw new Erfurt_Exception('Error while fetching model and namespace informations.');
         }
 
-
         if ($result === false) {
             throw new Erfurt_Exception('Error while fetching model and namespace informations.');
         } else {
             $this->_modelInfoCache = array();
 
-            #$rowSet = $result->fetchAll();
-            #var_dump($result);exit;
             foreach ($result as $row) {
                 if (!isset($this->_modelInfoCache[$row['uri']])) {
                     $this->_modelInfoCache[$row['uri']]['modelId']      = $row['id'];
@@ -1691,8 +1614,6 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
                     }
                 }
             }
-
-            //var_dump($this->_modelInfoCache);exit;
 
             // build the transitive closure for owl:imports
             // check for recursive owl:imports; also check for cylces!

--- a/library/Erfurt/Store/Adapter/Mssql.php
+++ b/library/Erfurt/Store/Adapter/Mssql.php
@@ -66,7 +66,9 @@ class Erfurt_Store_Adapter_Mssql implements Erfurt_Store_Adapter_Interface, Erfu
                 if (extension_loaded('sqlsrv')) {
                     $this->_dbConn = new Zend_Db_Adapter_Sqlsrv($adapterOptions);
                 } else {
-                    throw new Erfurt_Exception('Sqlsrv extension not found.', -1);
+                    throw new Erfurt_Exception(
+                        'Sqlsrv extension not found.',
+                    );
                 }
 
         try {
@@ -74,10 +76,17 @@ class Erfurt_Store_Adapter_Mssql implements Erfurt_Store_Adapter_Interface, Erfu
             $this->_dbConn->getConnection();
         } catch (Zend_Db_Adapter_Exception $e) {
             // maybe wrong login credentials or db-server not running?!
-            throw new Erfurt_Exception('Could not connect to database with name: "' . $dbname . '". Please check your credentials and whether the database exists and the server is running.', -1);
+            throw new Erfurt_Exception(
+                'Could not connect to database with name: "'
+                . $dbname
+                . '". Please check your credentials and whether the database exists and the server'
+                . ' is running.',
+            );
         } catch (Zend_Exception $e) {
             // maybe a needed php extension is not loaded?!
-            throw new Erfurt_Exception('An error with the specified database adapter occured.', -1);
+            throw new Erfurt_Exception(
+                'An error with the specified database adapter occured.',
+            );
         }
 
         // we want indexed results
@@ -290,16 +299,16 @@ class Erfurt_Store_Adapter_Mssql implements Erfurt_Store_Adapter_Interface, Erfu
 
     }
 
-    protected function _getNormalizedErrorCode()
+    protected function _isDuplicateEntryError()
     {
         if ($this->_dbConn instanceof Zend_Db_Adapter_Mysqli) {
             switch($this->_dbConn->getConnection()->errno) {
                 case 1062:
                     // duplicate entry
-                    return 1000;
+                    return true;
             }
         } else {
-            return -1;
+            return false;
         }
     }
 
@@ -1282,17 +1291,19 @@ class Erfurt_Store_Adapter_Mssql implements Erfurt_Store_Adapter_Interface, Erfu
                     try {
                         Erfurt_App::getInstance()->getStore()->checkSetup();
                     } catch (Erfurt_Store_Exception $e2) {
-                        if ($e2->getCode() == 20) {
+                        if ($e2->getCode() == Erfurt_Exception::SYSTEM_MODELS_IMPORTED) {
                             $this->_fetchModelInfos();
                         } else {
                             throw new Erfurt_Store_Adapter_Exception(
-                                'Store: Error while initializing the environment: '. $e2->getMessage(), -1);
+                                'Store: Error while initializing the environment: '. $e2->getMessage(),
+                            );
                         }
                     }
 
                 } else {
                     throw new Erfurt_Store_Adapter_Exception(
-                        'Store: Error while fetching model and namespace infos.', -1);
+                        'Store: Error while fetching model and namespace infos.',
+                    );
                 }
             }
         }
@@ -1377,9 +1388,11 @@ class Erfurt_Store_Adapter_Mssql implements Erfurt_Store_Adapter_Interface, Erfu
         try {
             $this->_dbConn->insert($tableName, $data);
         } catch (Exception $e) {
-            if ($this->_getNormalizedErrorCode() !== 1000) {
-                throw new Erfurt_Store_Adapter_Exception("Insertion of value into $tableName failed: " .
-                                $e->getMessage());
+            if (!$this->_isDuplicateEntryError()) {
+                throw new Erfurt_Store_Adapter_Exception(
+                    "Insertion of value into $tableName failed: "
+                    . $e->getMessage()
+                );
             }
         }
 

--- a/library/Erfurt/Store/Adapter/Stardog/ApiClient.php
+++ b/library/Erfurt/Store/Adapter/Stardog/ApiClient.php
@@ -304,7 +304,7 @@ class Erfurt_Store_Adapter_Stardog_ApiClient
                 $this->rollback();
             } catch (\Exception $rollbackException) {
                 $message = 'Transaction rollback failed: ' . PHP_EOL . $rollbackException;
-                throw new RuntimeException($message, 0, $e);
+                throw new RuntimeException($message, Erfurt_Exception::DEFAULT_ERROR, $e);
             }
             throw $e;
         }

--- a/library/Erfurt/Store/Exception.php
+++ b/library/Erfurt/Store/Exception.php
@@ -13,4 +13,5 @@
  */
 class Erfurt_Store_Exception extends Erfurt_Exception
 {
+    const NO_ERROR = 20;
 }

--- a/tests/unit/Erfurt/TestCase.php
+++ b/tests/unit/Erfurt/TestCase.php
@@ -93,7 +93,7 @@ class Erfurt_TestCase extends PHPUnit_Framework_TestCase
             $store->checkSetup();
             $this->_dbWasUsed = true;
         } catch (Erfurt_Store_Exception $e) {
-            if ($e->getCode() === 20) {
+            if ($e->getCode() === Erfurt_Exception::SYSTEM_MODELS_IMPORTED) {
                 // Setup successful
                 $this->_dbWasUsed = true;
             } else {


### PR DESCRIPTION
This pull request adds error codes for all Exceptions except for `NoViableAltException` and `EarlyExitException` as those both are used only in the Sparql Parser (and I doubt messing with it would be a good idea)

I created the following Error Codes:

`DEFAULT_ERROR` for 0 as 0 is the default output from the `getCode()` function of Exceptions
and the places where it appears most likely only wanted to use the third optional parameter for creating an Exception. 

`DATABASE_ERROR` and `PARSER_ERROR` for -1 as all those files used that number as general exception for the class (most likely only to use the third optional parameter as well)

`FILTER_ERROR` for 1 for the same reason as `DATABASE_ERROR` and `PARSER_ERROR`

`NO_ERROR` for 20 as the Exceptions with this number are ignored