### PR TITLE
Fix typo in graphId in EfZebndDb

### DIFF
--- a/library/Erfurt/Store/Adapter/EfZendDb.php
+++ b/library/Erfurt/Store/Adapter/EfZendDb.php
@@ -403,7 +403,7 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             $uriHash = md5($uri);
 
             $uriData = array(
-                'g'     => $graphid,
+                'g'     => $graphId,
                 'v'     => $uri,
                 'vh'    => $uriHash);
 
@@ -421,7 +421,7 @@ class Erfurt_Store_Adapter_EfZendDb implements Erfurt_Store_Adapter_Interface, E
             $baseHash = md5($baseUri);
 
             $baseData = array(
-                'g'     => $graphid,
+                'g'     => $graphId,
                 'v'     => $baseUri,
                 'vh'    => $baseHash);
 


### PR DESCRIPTION
This typo was introduced in 4034ba4af944496b53727558207e5ee0eb545df1.

**Unittests**
OK, but incomplete, skipped, or risky tests!            
Tests: 672, Assertions: 1350, Incomplete: 3, Skipped: 1.

**Integration Virtuoso**
OK, but incomplete, skipped, or risky tests!
Tests: 68, Assertions: 224, Skipped: 14.  

**Integration ZendDB**
OK, but incomplete, skipped, or risky tests!
Tests: 68, Assertions: 5834, Skipped: 12. 

**Integration Stardog**: Was skipped