### PR TITLE
Add config entry log.enable corresponding to the OntoWiki feature

### DIFF
--- a/library/Erfurt/App.php
+++ b/library/Erfurt/App.php
@@ -243,7 +243,9 @@ class Erfurt_App
                 define('_EFDEBUG', 1);
             }
 
-            // In debug mode log level is set to the highest value automatically.
+            //In debug mode logging is enabled and log level is set to the
+            //highest value automatically.
+            $config->log->enabled = true;
             $config->log->level = 7;
         }
 
@@ -697,7 +699,7 @@ class Erfurt_App
         if (!isset($this->_logObjects[$logIdentifier])) {
             $config = $this->getConfig();
 
-            if ((boolean)$config->log->level !== false) {
+            if ((boolean) $config->log->enabled == true) {
                 $logDir = $this->getLogDir();
 
                 $logWriter = null;
@@ -736,7 +738,7 @@ class Erfurt_App
             $logger = new Zend_Log($logWriter);
 
             // filter according to the given log level
-            if ((boolean) $config->log->level !== false) {
+            if ((boolean) $config->log->enabled == true) {
                 $levelFilter = new Zend_Log_Filter_Priority((int) $config->log->level, '<=');
                 $logger->addFilter($levelFilter);
             }

--- a/library/Erfurt/config/default.ini
+++ b/library/Erfurt/config/default.ini
@@ -135,6 +135,7 @@ ping.baseUri       = "http://purl.org/net/pingback/"
 ;   6: Informational - Informational messages
 ;   7: Debug         - Debug messages
 ;
+log.enabled = false
 log.level = false
 log.path  = "logs/"
 

--- a/tests/unit/Erfurt/AppTest.php
+++ b/tests/unit/Erfurt/AppTest.php
@@ -65,7 +65,8 @@ class Erfurt_AppTest extends Erfurt_TestCase
         $app = Erfurt_App::getInstance(false)->start($testConfig);
 
         $this->assertTrue(defined('_EFDEBUG'));
-        $this->assertEquals(7, $app->getConfig()->log->level);
+        $this->assertEquals(7, (int) $app->getConfig()->log->level);
+        $this->assertEquals(true, (boolean) $app->getConfig()->log->enabled);
         $this->assertEquals((E_ALL | E_STRICT), error_reporting());
     }
 
@@ -330,6 +331,7 @@ class Erfurt_AppTest extends Erfurt_TestCase
     {
         $app = Erfurt_App::getInstance();
         $config = $app->getConfig();
+        $config->log->enabled = true;
         $config->log->level = 7;
         $config->log->path  = $app->getTmpDir();
 


### PR DESCRIPTION
This pull request adds a new config entry log.enable which now handles (instead of a (boolean) false or (int) <=0 log.level. Furthermore the new entry is added everywhere it needs to

(OntoWiki pull request https://github.com/AKSW/OntoWiki/pull/404)